### PR TITLE
fix: 大写y仅在API24之后支持

### DIFF
--- a/growingio-tracker/src/main/java/com/growingio/android/sdk/track/middleware/DBSQLite.java
+++ b/growingio-tracker/src/main/java/com/growingio/android/sdk/track/middleware/DBSQLite.java
@@ -319,7 +319,7 @@ public class DBSQLite {
 
         @SuppressLint("SimpleDateFormat")
         private String hourStr() {
-            return new SimpleDateFormat("YYYYMMddHH").format(new Date());
+            return new SimpleDateFormat("yyyyMMddHH").format(new Date());
         }
 
         public void updateStatics(int generateNum, int sentSuccessNum,


### PR DESCRIPTION
https://developer.android.com/reference/java/text/SimpleDateFormat.html
"Y" 仅在API24+支持, 并且表示的是本周所属年份