### PR TITLE
fix: 层级通过dfs设置

### DIFF
--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/webservices/circle/entity/CircleScreenshot.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/webservices/circle/entity/CircleScreenshot.java
@@ -45,9 +45,7 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Queue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class CircleScreenshot {
@@ -214,20 +212,19 @@ public class CircleScreenshot {
                 return;
             }
 
-            Queue<ViewNode> queue = new LinkedList<>();
-            queue.add(topViewNode);
-            while (!queue.isEmpty()) {
-                ViewNode viewNode = queue.poll();
-                if (!disposeWebView(viewNode) && ViewUtil.canCircle(viewNode.getView())) {
-                    mViewElements.add(createViewElementBuilder(viewNode).build());
-                }
-                if (viewNode.getView() instanceof ViewGroup) {
-                    ViewGroup viewGroup = (ViewGroup) viewNode.getView();
-                    if (viewGroup.getChildCount() > 0) {
-                        for (int index = 0; index < viewGroup.getChildCount(); index++) {
-                            ViewNode childViewNode = viewNode.appendNode(viewGroup.getChildAt(index), index);
-                            queue.add(childViewNode);
-                        }
+            traverseViewNode(topViewNode);
+        }
+
+        private void traverseViewNode(ViewNode viewNode) {
+            if (!disposeWebView(viewNode) && ViewUtil.canCircle(viewNode.getView())) {
+                mViewElements.add(createViewElementBuilder(viewNode).build());
+            }
+            if (viewNode.getView() instanceof ViewGroup) {
+                ViewGroup viewGroup = (ViewGroup) viewNode.getView();
+                if (viewGroup.getChildCount() > 0) {
+                    for (int index = 0; index < viewGroup.getChildCount(); index++) {
+                        ViewNode childViewNode = viewNode.appendNode(viewGroup.getChildAt(index), index);
+                        traverseViewNode(childViewNode);
                     }
                 }
             }


### PR DESCRIPTION
层级通过dfs设置, 理论上应该保证和dispatchDraw的preOrderList一致, 对应方法在API29上设置灰名单, 需要考虑其它方式实现保证在自定义order的情况下zLevel有效