### PR TITLE
feat: 增加urlscheme打开debug

### DIFF
--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/log/CacheLogger.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/log/CacheLogger.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Beijing Yishu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.growingio.android.sdk.track.log;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class CacheLogger extends BaseLogger {
+    public static final String TYPE = "CacheLogger";
+
+    private final CircularFifoQueue<LogItem> mCacheLogs = new CircularFifoQueue<>(100);
+
+    @Override
+    protected synchronized void print(int priority, @NonNull String tag, @NonNull String message, @Nullable Throwable t) {
+        mCacheLogs.add(new LogItem.Builder()
+                .setPriority(priority)
+                .setTag(tag)
+                .setMessage(message)
+                .setThrowable(t)
+                .setTimeStamp(System.currentTimeMillis())
+                .build());
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    public synchronized List<LogItem> getCacheLogs() {
+        if (mCacheLogs.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<LogItem> copyList = new ArrayList<>(mCacheLogs.size());
+        copyList.addAll(mCacheLogs);
+
+        return copyList;
+    }
+}

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/log/CircularFifoQueue.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/log/CircularFifoQueue.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.growingio.android.sdk.track.webservices.log;
+package com.growingio.android.sdk.track.log;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/log/ErrorLogger.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/log/ErrorLogger.java
@@ -25,7 +25,7 @@ class ErrorLogger extends DebugLogger {
     @Override
     protected void print(int priority, @NonNull String tag, @NonNull String message, @Nullable Throwable t) {
         if (priority == Log.ERROR) {
-            super.print(priority, tag, message, t);
+            super.printWithoutCache(priority, tag, message, t);
         }
     }
 }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/log/LogItem.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/log/LogItem.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2020 Beijing Yishu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.growingio.android.sdk.track.log;
+
+public class LogItem {
+    private final int mPriority;
+    private final String mTag;
+    private final String mMessage;
+    private final Throwable mThrowable;
+    private final long mTimeStamp;
+
+    private LogItem(int priority, String tag, String message, Throwable throwable, long timeStamp) {
+        mPriority = priority;
+        mTag = tag;
+        mMessage = message;
+        mThrowable = throwable;
+        mTimeStamp = timeStamp;
+    }
+
+    public int getPriority() {
+        return mPriority;
+    }
+
+    public String getTag() {
+        return mTag;
+    }
+
+    public String getMessage() {
+        return mMessage;
+    }
+
+    public Throwable getThrowable() {
+        return mThrowable;
+    }
+
+    public long getTimeStamp() {
+        return mTimeStamp;
+    }
+
+    public static class Builder {
+        private int mPriority;
+        private String mTag;
+        private String mMessage;
+        private Throwable mThrowable;
+        private long mTimeStamp;
+
+        public Builder() {
+        }
+
+        public Builder setPriority(int priority) {
+            mPriority = priority;
+            return this;
+        }
+
+        public Builder setTag(String tag) {
+            mTag = tag;
+            return this;
+        }
+
+        public Builder setMessage(String message) {
+            mMessage = message;
+            return this;
+        }
+
+        public Builder setThrowable(Throwable throwable) {
+            mThrowable = throwable;
+            return this;
+        }
+
+        public Builder setTimeStamp(long timeStamp) {
+            mTimeStamp = timeStamp;
+            return this;
+        }
+
+        public LogItem build() {
+            return new LogItem(mPriority, mTag, mMessage, mThrowable, mTimeStamp);
+        }
+    }
+}

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/log/Logger.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/log/Logger.java
@@ -18,8 +18,6 @@ package com.growingio.android.sdk.track.log;
 
 import android.support.annotation.Nullable;
 
-import com.growingio.android.sdk.track.webservices.log.WsLogger;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -35,7 +33,7 @@ public class Logger {
 
     static {
         addLogger(new ErrorLogger());
-        addLogger(new WsLogger());
+        addLogger(new CacheLogger());
     }
 
     private Logger() {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/webservices/WebServicesProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/webservices/WebServicesProvider.java
@@ -23,6 +23,7 @@ import android.text.TextUtils;
 import com.growingio.android.sdk.track.ContextProvider;
 import com.growingio.android.sdk.track.listener.IActivityLifecycle;
 import com.growingio.android.sdk.track.listener.event.ActivityLifecycleEvent;
+import com.growingio.android.sdk.track.log.DebugLogger;
 import com.growingio.android.sdk.track.log.Logger;
 import com.growingio.android.sdk.track.providers.ActivityStateProvider;
 import com.growingio.android.sdk.track.webservices.log.MobileLogService;
@@ -83,6 +84,12 @@ public class WebServicesProvider implements IActivityLifecycle {
                         params.put(parameterName, data.getQueryParameter(parameterName));
                     }
                     startWebService(serviceType, params);
+                }
+                String openConsole = data.getQueryParameter("openConsoleLog");
+                if (!TextUtils.isEmpty(openConsole)) {
+                    if ("YES".equalsIgnoreCase(openConsole)) {
+                        Logger.addLogger(new DebugLogger());
+                    }
                 }
 //                intent.setData(null);
             }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/webservices/log/MobileLogService.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/webservices/log/MobileLogService.java
@@ -16,7 +16,6 @@
 
 package com.growingio.android.sdk.track.webservices.log;
 
-import com.growingio.android.sdk.track.log.ILogger;
 import com.growingio.android.sdk.track.log.Logger;
 import com.growingio.android.sdk.track.webservices.BaseWebSocketService;
 
@@ -27,16 +26,18 @@ public class MobileLogService extends BaseWebSocketService {
 
     @Override
     protected void onReady() {
-        ILogger logger = Logger.getLogger(WsLogger.TYPE);
-        if (logger instanceof WsLogger) {
-            mWsLogger = (WsLogger) logger;
-            mWsLogger.setCallback(new WsLogger.Callback() {
-                @Override
-                public void disposeLog(LoggerDataMessage logMessage) {
-                    sendMessage(logMessage.toJSONObject().toString());
-                }
-            });
+        super.onReady();
+        if (mWsLogger == null) {
+            mWsLogger = new WsLogger();
+            Logger.addLogger(mWsLogger);
         }
+
+        mWsLogger.setCallback(new WsLogger.Callback() {
+            @Override
+            public void disposeLog(LoggerDataMessage logMessage) {
+                sendMessage(logMessage.toJSONObject().toString());
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
 adb shell am start -d "growing.d80871b41ef40518://growingio/webservice?openConsoleLog=YES"
参数与iOS保持一致

Log中多线程问题存在的情况比较多, 整体上通过控制CacheLogger获取cache, 性能缺陷应该在CacheLogger的print中, syn如果升级也会导致获取cache阻塞. 
ErrorLogger 不获取cache
WsLogger与DebugLogger通过CAS判断是否获取过cache避免多线程异常, 理论上只需要一个线程输出cache
WsLogger的通过callback发送消息, okhttp的send函数也是synchronized标记的, 建立ws连接后, 调用send也会导致当前日志打印阻塞对应线程

考虑直接封装Logger + Executor主动控制线程, 然后在LogItem中增加Thread信息