### PR TITLE
add `Status.NOTCHANGED` support for each dir.

### DIFF
--- a/growingio-autotracker-gradle-plugin/src/main/java/com/growingio/sdk/plugin/autotrack/compile/AutotrackTransform.java
+++ b/growingio-autotracker-gradle-plugin/src/main/java/com/growingio/sdk/plugin/autotrack/compile/AutotrackTransform.java
@@ -218,11 +218,11 @@ public class AutotrackTransform extends Transform {
         final String relativeClassPath = file.getAbsolutePath().substring(inputDirPath.length());
         mExecutor.execute(() -> {
             File outFile = new File(outDirPath, relativeClassPath);
-            if (added==Status.REMOVED) {
+            if (added == Status.REMOVED) {
                 FileUtils.deleteQuietly(outFile);
-            } else if(added == Status.NOTCHANGED){
+            } else if (added == Status.NOTCHANGED) {
                 log("class file no change" + file);
-            }else { // ADDED or CHANGED
+            } else { // ADDED or CHANGED
                 if (relativeClassPath.endsWith(".class")) {
                     if (mClassRewriter.transformClassFile(file, outFile)) {
                         log("transformed class file " + file + " to " + outFile);


### PR DESCRIPTION
增量编译 DirectoryInput Status.NOTCHANGED 直接跳过，经过测试在项目中类文件较多时，第二次增量编译速度提升显著。至少在10倍以上。

测试方法：

使用 3 万个类文件测试。先clean。编译一次后，修改部分代码，再次编译。

测试结果：

优化前：
- 第一次编译 ：25.84秒 总共：2分52 秒
- 第二次编译 ：22.74秒 总共：1分14 秒

优化后：

- 第一次编译 ：26.57秒 总共：2分32 秒
- 第二次编译 ：0.75秒 总共：26.3 秒
