### PR TITLE
fix: PI-33712 代码触发click在page之前

### DIFF
--- a/demos/demo-autotrack/src/main/java/com/gio/test/three/autotrack/activity/ClickTestActivity.java
+++ b/demos/demo-autotrack/src/main/java/com/gio/test/three/autotrack/activity/ClickTestActivity.java
@@ -23,6 +23,7 @@ import android.view.Menu;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.CheckBox;
+import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.RatingBar;
 import android.widget.SeekBar;
@@ -63,6 +64,8 @@ public class ClickTestActivity extends Activity {
         radioGroup.setOnCheckedChangeListener((group, checkedId) -> {
 
         });
+        RadioButton radioButton = findViewById(R.id.rb_male);
+        radioGroup.check(radioButton.getId());
 
         Switch switchBtn = findViewById(R.id.switch1);
         switchBtn.setOnCheckedChangeListener((buttonView, isChecked) -> {

--- a/demos/demo-autotrack/src/main/res/layout/activity_click_test.xml
+++ b/demos/demo-autotrack/src/main/res/layout/activity_click_test.xml
@@ -51,11 +51,13 @@
         android:layout_height="wrap_content">
 
         <RadioButton
+            android:id="@+id/rb_male"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="male" />
 
         <RadioButton
+            android:id="@+id/rb_female"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="female" />

--- a/demos/demo/src/androidTest/java/com/growingio/autotest/autotracker/ViewClickEventsTest.java
+++ b/demos/demo/src/androidTest/java/com/growingio/autotest/autotracker/ViewClickEventsTest.java
@@ -174,21 +174,21 @@ public class ViewClickEventsTest extends EventsTest {
                 receivedEvent,
                 new ViewElementEvent.Builder()
                         .setPath("/ClickTestActivity")
-                        .setXpath("/Page/ActionBarOverlayLayout[0]/FrameLayout[0]/LinearLayout[0]#content_parent/RadioGroup[0]#radio_group_gender/RadioButton[0]")
-                        .setTextValue("male")
+                        .setXpath("/Page/ActionBarOverlayLayout[0]/FrameLayout[0]/LinearLayout[0]#content_parent/RadioGroup[0]#radio_group_gender/RadioButton[1]#rb_female")
+                        .setTextValue("female")
                         .setIndex(-1)
                         .build(),
                 new ViewElementEvent.Builder()
                         .setPath("/ClickTestActivity")
-                        .setXpath("/Page/ActionBarOverlayLayout[0]/FrameLayout[0]/LinearLayout[0]#content_parent/RadioGroup[0]#radio_group_gender/RadioButton[1]")
-                        .setTextValue("female")
+                        .setXpath("/Page/ActionBarOverlayLayout[0]/FrameLayout[0]/LinearLayout[0]#content_parent/RadioGroup[0]#radio_group_gender/RadioButton[0]#rb_male")
+                        .setTextValue("male")
                         .setIndex(-1)
                         .build()
 
         ));
         ActivityScenario<ClickTestActivity> scenario = ActivityScenario.launch(ClickTestActivity.class);
-        onView(withText("male")).perform(click());
         onView(withText("female")).perform(click());
+        onView(withText("male")).perform(click());
         Awaiter.untilTrue(receivedEvent);
 
         scenario.close();

--- a/demos/demo/src/androidTest/java/com/growingio/autotest/autotracker/webservices/CircleServiceTest.java
+++ b/demos/demo/src/androidTest/java/com/growingio/autotest/autotracker/webservices/CircleServiceTest.java
@@ -93,8 +93,8 @@ public class CircleServiceTest extends WebServicesTest {
             add("/Page/ActionBarOverlayLayout[0]/FrameLayout[0]/LinearLayout[0]#content_parent/SeekBar[0]#seek_bar");
             add("/Page/ActionBarOverlayLayout[0]/FrameLayout[0]/LinearLayout[0]#content_parent/RatingBar[0]#rating_bar");
             add("/Page/ActionBarOverlayLayout[0]/FrameLayout[0]/LinearLayout[0]#content_parent/Spinner[0]#spinner_test/TextView[-]");
-            add("/Page/ActionBarOverlayLayout[0]/FrameLayout[0]/LinearLayout[0]#content_parent/RadioGroup[0]#radio_group_gender/RadioButton[0]");
-            add("/Page/ActionBarOverlayLayout[0]/FrameLayout[0]/LinearLayout[0]#content_parent/RadioGroup[0]#radio_group_gender/RadioButton[1]");
+            add("/Page/ActionBarOverlayLayout[0]/FrameLayout[0]/LinearLayout[0]#content_parent/RadioGroup[0]#radio_group_gender/RadioButton[0]#rb_male");
+            add("/Page/ActionBarOverlayLayout[0]/FrameLayout[0]/LinearLayout[0]#content_parent/RadioGroup[0]#radio_group_gender/RadioButton[1]#rb_female");
             add("/Page/ActionBarOverlayLayout[0]/FrameLayout[0]/LinearLayout[0]#content_parent/EditText[0]#test_input");
             add("/Page/MenuView/MenuItem#navigation_home");
             add("/Page/MenuView/MenuItem#navigation_dashboard");

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/change/ViewChangeProvider.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/change/ViewChangeProvider.java
@@ -89,6 +89,10 @@ public class ViewChangeProvider implements IActivityLifecycle, OnViewStateChange
 
     private static void sendChangeEvent(ViewNode viewNode) {
         Page<?> page = PageProvider.get().findPage(viewNode.getView());
+        if (page == null) {
+            Logger.e(TAG, "sendChangeEvent page Activity is NULL");
+            return;
+        }
         TrackMainThread.trackMain().postEventToTrackMain(
                 new ViewElementEvent.Builder()
                         .setEventType(AutotrackEventType.VIEW_CHANGE)

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/click/ViewClickProvider.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/click/ViewClickProvider.java
@@ -161,6 +161,10 @@ class ViewClickProvider {
     }
 
     private static void sendClickEvent(Page<?> page, ViewNode viewNode) {
+        if (page == null) {
+            Logger.e(TAG, "sendClickEvent page Activity is NULL");
+            return;
+        }
         TrackMainThread.trackMain().postEventToTrackMain(
                 new ViewElementEvent.Builder()
                         .setEventType(AutotrackEventType.VIEW_CLICK)


### PR DESCRIPTION
满足类似如下场景, 如果代码触发的click事件不进行采集, 仅采集用户行为数据
在oncreate阶段 主动调用click事件 如:RadioGroup默认选择

不提前page的原因, 用户需要在onCreate阶段设置ignore以及alias
虽然可以在super.onCreate之前调用, 但是会带来更大的解释成本