### PR TITLE
fix: 注入时invoke-static调用virtual方法

### DIFF
--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/hybrid/WebViewInjector.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/hybrid/WebViewInjector.java
@@ -26,6 +26,9 @@ import java.util.Map;
 public class WebViewInjector {
     private static final String TAG = "WebViewInjector";
 
+    private WebViewInjector() {
+    }
+
     @Before(clazz = WebView.class, method = "loadUrl", parameterTypes = {String.class})
     public static void webkitWebViewLoadUrl(WebView webView, String url) {
         Logger.d(TAG, "webkitWebViewLoadUrl: webView = " + webView.getClass().getName() + ", url = " + url);
@@ -81,19 +84,19 @@ public class WebViewInjector {
     }
 
     @Before(clazz = WebView.class, method = "loadDataWithBaseURL", parameterTypes = {String.class, String.class, String.class, String.class, String.class})
-    public void webkitWebViewLoadDataWithBaseURL(WebView webView, String baseUrl, String data, String mimeType, String encoding, String historyUrl) {
+    public static void webkitWebViewLoadDataWithBaseURL(WebView webView, String baseUrl, String data, String mimeType, String encoding, String historyUrl) {
         Logger.d(TAG, "webkitWebViewLoadDataWithBaseURL: webView = " + webView.getClass().getName());
         HybridBridgeProvider.get().bridgeForWebView(SuperWebView.make(webView));
     }
 
     @Before(clazz = com.tencent.smtt.sdk.WebView.class, method = "loadDataWithBaseURL", parameterTypes = {String.class, String.class, String.class, String.class, String.class})
-    public void x5WebViewLoadDataWithBaseURL(com.tencent.smtt.sdk.WebView webView, String baseUrl, String data, String mimeType, String encoding, String historyUrl) {
+    public static void x5WebViewLoadDataWithBaseURL(com.tencent.smtt.sdk.WebView webView, String baseUrl, String data, String mimeType, String encoding, String historyUrl) {
         Logger.d(TAG, "x5WebViewLoadDataWithBaseURL: webView = " + webView.getClass().getName());
         HybridBridgeProvider.get().bridgeForWebView(SuperWebView.make(webView));
     }
 
     @Before(clazz = com.uc.webview.export.WebView.class, method = "loadDataWithBaseURL", parameterTypes = {String.class, String.class, String.class, String.class, String.class})
-    public void ucWebViewLoadDataWithBaseURL(com.uc.webview.export.WebView webView, String baseUrl, String data, String mimeType, String encoding, String historyUrl) {
+    public static void ucWebViewLoadDataWithBaseURL(com.uc.webview.export.WebView webView, String baseUrl, String data, String mimeType, String encoding, String historyUrl) {
         Logger.d(TAG, "ucWebViewLoadDataWithBaseURL: webView = " + webView.getClass().getName());
         HybridBridgeProvider.get().bridgeForWebView(SuperWebView.make(webView));
     }


### PR DESCRIPTION
注入时invoke-static调用virtual方法
java.lang.IncompatibleClassChangeError
The method 'void com.growingio.android.sdk.autotrack.hybrid.WebViewInjector.webkitWebViewLoadDataWithBaseURL(android.webkit.WebView, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String)' was expected to be of type static but instead was found to be of type virtual