### PR TITLE
fix: workspace为url, 特殊字符导致异常

### DIFF
--- a/gradle/publishAllToMavenLocal.sh
+++ b/gradle/publishAllToMavenLocal.sh
@@ -2,7 +2,6 @@
 
 export IS_EXCLUDE_DEMOS=true
 ./gradlew clean \
-&& ./gradlew :growingio-autotracker-gradle-plugin:publishMavenAgentPublicationToMavenLocal \
 && ./gradlew :growingio-annotation:publishMavenAgentPublicationToMavenLocal \
 && ./gradlew :growingio-annotation:compiler:publishMavenAgentPublicationToMavenLocal \
 && ./gradlew :growingio-tracker-core:publishMavenAgentPublicationToMavenLocal \
@@ -19,5 +18,6 @@ export IS_EXCLUDE_DEMOS=true
 && ./gradlew :gio-sdk:tracker-cdp:publishMavenAgentPublicationToMavenLocal \
 && ./gradlew :gio-sdk:autotracker:publishMavenAgentPublicationToMavenLocal \
 && ./gradlew :gio-sdk:autotracker-cdp:publishMavenAgentPublicationToMavenLocal \
+&& ./gradlew :growingio-autotracker-gradle-plugin:publishMavenAgentPublicationToMavenLocal \
 && ./gradlew clean
 export IS_EXCLUDE_DEMOS=false

--- a/inject-annotation/compiler/src/main/java/com/growingio/sdk/inject/compiler/InjectProcessor.java
+++ b/inject-annotation/compiler/src/main/java/com/growingio/sdk/inject/compiler/InjectProcessor.java
@@ -349,7 +349,6 @@ public class InjectProcessor extends AbstractProcessor {
     }
 
     private String getProjectRootPath() {
-        String jarPath = getClass().getProtectionDomain().getCodeSource().getLocation().getPath();
-        return new File(jarPath).getParentFile().getParentFile().getParentFile().getParentFile().getParent();
+        return System.getProperty("user.dir");
     }
 }


### PR DESCRIPTION
workspace如果有空格, 原先获取rootpath的方式为url, 需要使用URLDecode.decode, 否则会导致FileNotFoundException
plugin需要使用到autotracker-core生成的文件, 所以将执行顺序放置到末尾