### PR TITLE
fix: sonarcloud check

### DIFF
--- a/growingio-autotracker-gradle-plugin/src/main/java/com/growingio/sdk/plugin/autotrack/AutotrackPlugin.java
+++ b/growingio-autotracker-gradle-plugin/src/main/java/com/growingio/sdk/plugin/autotrack/AutotrackPlugin.java
@@ -121,12 +121,13 @@ public class AutotrackPlugin implements Plugin<Project> {
     public String getPluginVersion() {
         try {
             String jarPath = URLDecoder.decode(new File(ClassRewriter.class.getProtectionDomain().getCodeSource().getLocation().getPath()).getCanonicalPath());
-            JarInputStream inputStream = new JarInputStream(new FileInputStream(jarPath));
-            String pluginVersion = inputStream.getManifest().getMainAttributes().getValue("Gradle-Plugin-Version");
-            if (pluginVersion == null) {
-                throw new AutotrackBuildException("Cannot find GrowingIO autotrack gradle plugin version");
+            try (JarInputStream inputStream = new JarInputStream(new FileInputStream(jarPath))) {
+                String pluginVersion = inputStream.getManifest().getMainAttributes().getValue("Gradle-Plugin-Version");
+                if (pluginVersion == null) {
+                    throw new AutotrackBuildException("Cannot find GrowingIO autotrack gradle plugin version");
+                }
+                return pluginVersion;
             }
-            return pluginVersion;
         } catch (IOException e) {
             throw new AutotrackBuildException("Cannot find GrowingIO autotrack gradle plugin version");
         }

--- a/growingio-autotracker-gradle-plugin/src/main/java/com/growingio/sdk/plugin/autotrack/compile/AutotrackTransform.java
+++ b/growingio-autotracker-gradle-plugin/src/main/java/com/growingio/sdk/plugin/autotrack/compile/AutotrackTransform.java
@@ -172,7 +172,7 @@ public class AutotrackTransform extends Transform {
             return;
         }
         if (out.exists()) {
-            out.delete();
+            FileUtils.deleteQuietly(out);
         }
         if (isIncremental && jarInput.getStatus() == Status.REMOVED) {
             return;

--- a/growingio-network/volley/src/main/java/com/growingio/android/volley/VolleyDataFetcher.java
+++ b/growingio-network/volley/src/main/java/com/growingio/android/volley/VolleyDataFetcher.java
@@ -82,7 +82,8 @@ public class VolleyDataFetcher implements DataFetcher<EventResponse> {
         try {
             return future.get(5L, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
-            Logger.e(TAG, e);
+            Logger.e(TAG, e, "executeData interrupted");
+            Thread.currentThread().interrupt();
         } catch (ExecutionException e) {
             Logger.e(TAG, e);
         } catch (TimeoutException e) {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/MultiProcessDataSharer.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/MultiProcessDataSharer.java
@@ -70,7 +70,9 @@ public class MultiProcessDataSharer implements IDataSharer {
                 Logger.d(TAG, "awaitLoadedLocked");
                 wait();
                 Logger.d(TAG, "awaitLoadedLocked end");
-            } catch (InterruptedException ignored) {
+            } catch (InterruptedException e) {
+                Logger.e(TAG, e, "awaitLoadedLocked interrupted");
+                Thread.currentThread().interrupt();
             }
         }
     }
@@ -85,7 +87,7 @@ public class MultiProcessDataSharer implements IDataSharer {
             try {
                 RandomAccessFile randomAccessFile = new RandomAccessFile(file, "rw");
                 mFileChannel = randomAccessFile.getChannel();
-                mMappedByteBuffer = mFileChannel.map(FileChannel.MapMode.READ_WRITE, 0, mMaxSize * SharedEntry.MAX_SIZE);
+                mMappedByteBuffer = mFileChannel.map(FileChannel.MapMode.READ_WRITE, 0, (long) mMaxSize * SharedEntry.MAX_SIZE);
                 incrementLoadFromDisk();
             } catch (IOException e) {
                 Logger.e(TAG, e);

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/middleware/EventsSQLite.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/middleware/EventsSQLite.java
@@ -27,7 +27,7 @@ import java.util.List;
 public class EventsSQLite {
     private static final String TAG = "EventsSQLite";
 
-    private static final long EVENT_VALID_PERIOD_MILLS = 7 * 24 * 60 * 60_000;
+    private static final long EVENT_VALID_PERIOD_MILLS = 7L * 24 * 60 * 60_000;
 
     private final EventsManager mEventsManager;
 

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/SessionProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/SessionProvider.java
@@ -55,7 +55,7 @@ public class SessionProvider implements IActivityLifecycle, OnUserIdChangedListe
 
     private SessionProvider() {
         mContext = TrackerContext.get().getApplicationContext();
-        mSessionInterval = ConfigurationProvider.core().getSessionInterval() * 1000;
+        mSessionInterval = ConfigurationProvider.core().getSessionInterval() * 1000L;
         ActivityStateProvider.get().registerActivityLifecycleListener(this);
     }
 

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/JsonUtil.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/JsonUtil.java
@@ -31,7 +31,7 @@ public final class JsonUtil {
     /**
      * @return true if left and right key value equal,
      */
-    public static boolean equal(JSONObject left, JSONObject right) {
+    public static boolean equals(JSONObject left, JSONObject right) {
         if (left == null || right == null) {
             return left == right;
         }
@@ -46,7 +46,7 @@ public final class JsonUtil {
                 Object leftValue = left.get(key);
                 Object rightValue = right.get(key);
                 // leftValue and rightValue all not null
-                if (!jsonEqual(leftValue, rightValue)) {
+                if (!jsonEquals(leftValue, rightValue)) {
                     return false;
                 }
             }
@@ -56,13 +56,13 @@ public final class JsonUtil {
         return true;
     }
 
-    private static boolean jsonEqual(Object left, Object right) {
+    private static boolean jsonEquals(Object left, Object right) {
         if (ObjectUtils.equals(left, right)) {
             return true;
         } else if (left instanceof JSONObject && right instanceof JSONObject) {
-            return equal((JSONObject) left, (JSONObject) right);
+            return equals((JSONObject) left, (JSONObject) right);
         } else if (left instanceof JSONArray && right instanceof JSONArray) {
-            return equal((JSONArray) left, (JSONArray) right);
+            return equals((JSONArray) left, (JSONArray) right);
         }
         return false;
     }
@@ -70,7 +70,7 @@ public final class JsonUtil {
     /**
      * @return true if left and right key value equal,
      */
-    public static boolean equal(JSONArray left, JSONArray right) {
+    public static boolean equals(JSONArray left, JSONArray right) {
         if (left == null || right == null) {
             return left == right;
         }
@@ -81,7 +81,7 @@ public final class JsonUtil {
             for (int i = 0; i < left.length(); i++) {
                 Object leftValue = left.get(i);
                 Object rightValue = right.get(i);
-                if (!jsonEqual(leftValue, rightValue)) {
+                if (!jsonEquals(leftValue, rightValue)) {
                     return false;
                 }
             }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/OaidHelper.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/OaidHelper.java
@@ -70,7 +70,8 @@ public class OaidHelper implements IIdentifierListener {
                     try {
                         this.wait(3000L);
                     } catch (InterruptedException e) {
-                        e.printStackTrace();
+                        Logger.e(TAG, e, "awaitLoadedLocked interrupted");
+                        Thread.currentThread().interrupt();
                     }
 
                     if (!this.mComplete) {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/SystemUtil.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/SystemUtil.java
@@ -53,10 +53,9 @@ public class SystemUtil {
     public static String getProcessName() {
         try {
             File file = new File("/proc/" + android.os.Process.myPid() + "/" + "cmdline");
-            BufferedReader mBufferedReader = new BufferedReader(new FileReader(file));
-            String processName = mBufferedReader.readLine().trim();
-            mBufferedReader.close();
-            return processName;
+            try (BufferedReader mBufferedReader = new BufferedReader(new FileReader(file))) {
+                return mBufferedReader.readLine().trim();
+            }
         } catch (Exception e) {
             Logger.e(TAG, e);
             return null;


### PR DESCRIPTION
Rule S3077  should not apply to references to immutable objects
[[Java] Rule S3077 should not apply to references to immutable objects  ](https://community.sonarsource.com/t/java-rule-s3077-should-not-apply-to-references-to-immutable-objects/15200)

volatile检测目前依据关键字, 实际是否安全, 对象是否可变需要自己进行判断

Rule S2583 Conditionally executed code should be reachable
[Differentiate potentially not nullable values from certainly nullable values](https://jira.sonarsource.com/browse/MMF-1767)

NonNull不能保证运行时安全, 目前认为这是个功能, 不放在短期计划中修改

Rule S2259 Null pointers should not be dereferenced
[S2259: Null pointers should not be dereferenced ](https://community.sonarsource.com/t/s2259-null-pointers-should-not-be-dereferenced/5786)

官方认为跨文件的方法分析比较消耗资源, 所以暂时没有开放该特性

