### PR TITLE
fix: sonarcloud check

### DIFF
--- a/growingio-autotracker-gradle-plugin/src/main/java/com/growingio/sdk/plugin/autotrack/AutotrackPlugin.java
+++ b/growingio-autotracker-gradle-plugin/src/main/java/com/growingio/sdk/plugin/autotrack/AutotrackPlugin.java
@@ -121,12 +121,13 @@ public class AutotrackPlugin implements Plugin<Project> {
     public String getPluginVersion() {
         try {
             String jarPath = URLDecoder.decode(new File(ClassRewriter.class.getProtectionDomain().getCodeSource().getLocation().getPath()).getCanonicalPath());
-            JarInputStream inputStream = new JarInputStream(new FileInputStream(jarPath));
-            String pluginVersion = inputStream.getManifest().getMainAttributes().getValue("Gradle-Plugin-Version");
-            if (pluginVersion == null) {
-                throw new AutotrackBuildException("Cannot find GrowingIO autotrack gradle plugin version");
+            try (JarInputStream inputStream = new JarInputStream(new FileInputStream(jarPath))) {
+                String pluginVersion = inputStream.getManifest().getMainAttributes().getValue("Gradle-Plugin-Version");
+                if (pluginVersion == null) {
+                    throw new AutotrackBuildException("Cannot find GrowingIO autotrack gradle plugin version");
+                }
+                return pluginVersion;
             }
-            return pluginVersion;
         } catch (IOException e) {
             throw new AutotrackBuildException("Cannot find GrowingIO autotrack gradle plugin version");
         }

--- a/growingio-autotracker-gradle-plugin/src/main/java/com/growingio/sdk/plugin/autotrack/compile/AutotrackTransform.java
+++ b/growingio-autotracker-gradle-plugin/src/main/java/com/growingio/sdk/plugin/autotrack/compile/AutotrackTransform.java
@@ -172,7 +172,7 @@ public class AutotrackTransform extends Transform {
             return;
         }
         if (out.exists()) {
-            out.delete();
+            FileUtils.deleteQuietly(out);
         }
         if (isIncremental && jarInput.getStatus() == Status.REMOVED) {
             return;

--- a/growingio-network/volley/src/main/java/com/growingio/android/volley/VolleyDataFetcher.java
+++ b/growingio-network/volley/src/main/java/com/growingio/android/volley/VolleyDataFetcher.java
@@ -82,7 +82,8 @@ public class VolleyDataFetcher implements DataFetcher<EventResponse> {
         try {
             return future.get(5L, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
-            Logger.e(TAG, e);
+            Logger.e(TAG, e, "executeData interrupted");
+            Thread.currentThread().interrupt();
         } catch (ExecutionException e) {
             Logger.e(TAG, e);
         } catch (TimeoutException e) {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/MultiProcessDataSharer.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/MultiProcessDataSharer.java
@@ -70,7 +70,9 @@ public class MultiProcessDataSharer implements IDataSharer {
                 Logger.d(TAG, "awaitLoadedLocked");
                 wait();
                 Logger.d(TAG, "awaitLoadedLocked end");
-            } catch (InterruptedException ignored) {
+            } catch (InterruptedException e) {
+                Logger.e(TAG, e, "awaitLoadedLocked interrupted");
+                Thread.currentThread().interrupt();
             }
         }
     }
@@ -85,7 +87,7 @@ public class MultiProcessDataSharer implements IDataSharer {
             try {
                 RandomAccessFile randomAccessFile = new RandomAccessFile(file, "rw");
                 mFileChannel = randomAccessFile.getChannel();
-                mMappedByteBuffer = mFileChannel.map(FileChannel.MapMode.READ_WRITE, 0, mMaxSize * SharedEntry.MAX_SIZE);
+                mMappedByteBuffer = mFileChannel.map(FileChannel.MapMode.READ_WRITE, 0, (long) mMaxSize * SharedEntry.MAX_SIZE);
                 incrementLoadFromDisk();
             } catch (IOException e) {
                 Logger.e(TAG, e);

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/middleware/EventSender.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/middleware/EventSender.java
@@ -31,7 +31,6 @@ import com.growingio.android.sdk.track.ipc.ProcessLock;
 import com.growingio.android.sdk.track.log.Logger;
 import com.growingio.android.sdk.track.utils.NetworkUtil;
 
-import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -178,13 +177,7 @@ public class EventSender {
      * @param onlyInstant true -- 仅发送实时消息
      */
     void sendEvents(boolean onlyInstant) {
-        boolean locked = true;
-        try {
-            locked = mProcessLock.tryLock();
-        } catch (IOException e) {
-            Logger.e(TAG, e);
-        }
-        if (!locked) {
+        if (!mProcessLock.isAcquired()) {
             Logger.e(TAG, "sendEvents: this process can not get lock");
             return;
         }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/middleware/EventsSQLite.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/middleware/EventsSQLite.java
@@ -42,7 +42,7 @@ import static com.growingio.android.sdk.track.middleware.EventsInfoTable.putValu
 public class EventsSQLite {
     private static final String TAG = "EventsSQLite";
 
-    private static final long EVENT_VALID_PERIOD_MILLS = 7 * 24 * 60 * 60_000;
+    private static final long EVENT_VALID_PERIOD_MILLS = 7L * 24 * 60 * 60_000;
 
     private final Context context;
     private final String eventsInfoAuthority;

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/SessionProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/SessionProvider.java
@@ -55,7 +55,7 @@ public class SessionProvider implements IActivityLifecycle, OnUserIdChangedListe
 
     private SessionProvider() {
         mContext = TrackerContext.get().getApplicationContext();
-        mSessionInterval = ConfigurationProvider.core().getSessionInterval() * 1000;
+        mSessionInterval = ConfigurationProvider.core().getSessionInterval() * 1000L;
         ActivityStateProvider.get().registerActivityLifecycleListener(this);
     }
 

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/OaidHelper.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/OaidHelper.java
@@ -73,7 +73,8 @@ public class OaidHelper {
                     try {
                         this.wait(duration);
                     } catch (InterruptedException e) {
-                        e.printStackTrace();
+                        Logger.e(TAG, e, "waitCompleteAndGetOaid interrupted");
+                        Thread.currentThread().interrupt();
                     }
 
                     if (!this.mComplete) {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/SystemUtil.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/SystemUtil.java
@@ -31,29 +31,12 @@ public class SystemUtil {
     private SystemUtil() {
     }
 
-/*    public static void killAppProcess(Context context) {
-        //注意：不能先杀掉主进程，否则逻辑代码无法继续执行，需先杀掉相关进程最后杀掉主进程
-        ActivityManager mActivityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
-        List<ActivityManager.RunningAppProcessInfo> processes = mActivityManager.getRunningAppProcesses();
-        if (processes != null && !processes.isEmpty()) {
-            for (ActivityManager.RunningAppProcessInfo runningAppProcessInfo : processes) {
-                if (runningAppProcessInfo.pid != android.os.Process.myPid()) {
-                    Process.killProcess(runningAppProcessInfo.pid);
-                }
-            }
-        }
-
-        Process.killProcess(Process.myPid());
-        System.exit(0);
-    }*/
-
     public static String getProcessName() {
         try {
-            File file = new File("/proc/" + android.os.Process.myPid() + "/" + "cmdline");
-            BufferedReader mBufferedReader = new BufferedReader(new FileReader(file));
-            String processName = mBufferedReader.readLine().trim();
-            mBufferedReader.close();
-            return processName;
+            try (BufferedReader mBufferedReader = new BufferedReader(
+                    new FileReader(new File("/proc/" + android.os.Process.myPid() + "/" + "cmdline")))) {
+                return mBufferedReader.readLine().trim();
+            }
         } catch (Exception e) {
             Logger.e(TAG, e);
             return null;


### PR DESCRIPTION
优化了一下ProcessLock

Rule S3077 should not apply to references to immutable objects
[Java] Rule S3077 should not apply to references to immutable objects

volatile检测目前依据关键字, 实际是否安全, 对象是否可变需要自己进行判断

Rule S2583 Conditionally executed code should be reachable
Differentiate potentially not nullable values from certainly nullable values

NonNull不能保证运行时安全, 目前认为这是个功能, 不放在短期计划中修改

Rule S2259 Null pointers should not be dereferenced
S2259: Null pointers should not be dereferenced

官方认为跨文件的方法分析比较消耗资源, 所以暂时没有开放该特性