### PR TITLE
feat: 增加userKey字段

### DIFF
--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/CoreConfiguration.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/CoreConfiguration.java
@@ -39,6 +39,7 @@ public class CoreConfiguration implements Configurable {
     private int mExcludeEventFlag = EventExcludeFilter.EVENT_MASK_NONE;
     private int mIgnoreFieldFlag = FieldIgnoreFilter.FIELD_IGNORE_NONE;
     private final List<LibraryGioModule> mComponents = new ArrayList<>();
+    private boolean mIdMappingEnabled = false;
 
     public CoreConfiguration(String projectId, String urlScheme) {
         mProjectId = projectId;
@@ -170,6 +171,15 @@ public class CoreConfiguration implements Configurable {
 
     public List<LibraryGioModule> getPreoloadComponents() {
         return mComponents;
+    }
+
+    public boolean isIdMappingEnabled() {
+        return mIdMappingEnabled;
+    }
+
+    public CoreConfiguration setIdMappingEnabled(boolean enabled) {
+        this.mIdMappingEnabled = enabled;
+        return (CoreConfiguration) this;
     }
 
 }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
@@ -159,6 +159,11 @@ public class Tracker {
         TrackMainThread.trackMain().postActionToTrackMain(() -> UserInfoProvider.get().setLoginUserId(userId));
     }
 
+    public void setLoginUserId(final String userId, final String userKey) {
+        if (!isInited) return;
+        TrackMainThread.trackMain().postActionToTrackMain(() -> UserInfoProvider.get().setLoginUserId(userId, userKey));
+    }
+
     public void cleanLoginUserId() {
         if (!isInited) return;
         TrackMainThread.trackMain().postActionToTrackMain(() -> UserInfoProvider.get().setLoginUserId(null));

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ErrorLog.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ErrorLog.java
@@ -27,7 +27,8 @@ public class ErrorLog {
     public static final String JSON_TOO_LONG = "JSONObject传参最长仅支持100个键值对";
     public static final String JSON_KEY_VALUE_NOT_VALID = "JSONObject传参中键值对不合法, 发送失败";
     public static final String TRACK_FRAGMENT_ERROR = "trackAllFragment策略与全局策略相同， 不需要单独设置";
-    public static final String USER_ID_TOO_LONG = "GrowingIO.setUserId(VALUE):VALUE长度大于1000，不发送";
+    public static final String USER_KEY_TOO_LONG = "GrowingIO.setUserId(KEY, VALUE):KEY长度大于1000，不发送";
+    public static final String USER_ID_TOO_LONG = "GrowingIO.setUserId(KEY, VALUE):VALUE长度大于1000，不发送";
 
     private ErrorLog() {
     }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/data/PersistentDataProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/data/PersistentDataProvider.java
@@ -32,6 +32,7 @@ import com.growingio.android.sdk.track.log.Logger;
 import com.growingio.android.sdk.track.providers.SessionProvider;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -42,6 +43,7 @@ public class PersistentDataProvider {
     private static final int SHARER_MAX_SIZE = 50;
 
     private static final String KEY_TYPE_GLOBAL = "TYPE_GLOBAL";
+    private static final String KEY_LOGIN_USER_KEY = "LOGIN_USER_KEY";
     private static final String KEY_LOGIN_USER_ID = "LOGIN_USER_ID";
     private static final String KEY_DEVICE_ID = "DEVICE_ID";
     private static final String KEY_SESSION_ID = "SESSION_ID";
@@ -99,12 +101,19 @@ public class PersistentDataProvider {
         mDataSharer.putString(KEY_DEVICE_ID, deviceId);
     }
 
+    public String getLoginUserKey() {
+        return mDataSharer.getString(KEY_LOGIN_USER_KEY, "");
+    }
+
     public String getLoginUserId() {
         return mDataSharer.getString(KEY_LOGIN_USER_ID, "");
     }
 
-    public void setLoginUserId(@Nullable String userId) {
-        mDataSharer.putString(KEY_LOGIN_USER_ID, userId);
+    public void setLoginUserIdAndUserKey(@Nullable String userId, @Nullable String userKey) {
+        HashMap<String, String> map = new HashMap<>();
+        map.put(KEY_LOGIN_USER_ID, userId);
+        map.put(KEY_LOGIN_USER_KEY, userKey);
+        mDataSharer.putMultiString(map);
     }
 
     public String getLatestNonNullUserId() {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/base/BaseEvent.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/base/BaseEvent.java
@@ -51,6 +51,7 @@ public abstract class BaseEvent extends GEvent {
     private final String mPlatform;
     private final String mPlatformVersion;
     private final String mDeviceId;
+    private final String mUserKey;
     private final String mUserId;
     private final String mSessionId;
     private final String mEventType;
@@ -80,6 +81,7 @@ public abstract class BaseEvent extends GEvent {
         mPlatform = eventBuilder.mPlatform;
         mPlatformVersion = eventBuilder.mPlatformVersion;
         mDeviceId = eventBuilder.mDeviceId;
+        mUserKey = eventBuilder.mUserKey;
         mUserId = eventBuilder.mUserId;
         mSessionId = eventBuilder.mSessionId;
         mEventType = eventBuilder.mEventType;
@@ -108,6 +110,10 @@ public abstract class BaseEvent extends GEvent {
 
     public String getDeviceId() {
         return mDeviceId;
+    }
+
+    public String getUserKey() {
+        return mUserKey;
     }
 
     public String getUserId() {
@@ -210,6 +216,9 @@ public abstract class BaseEvent extends GEvent {
             json.put("platform", mPlatform);
             json.put("platformVersion", mPlatformVersion);
             json.put("deviceId", getDeviceId());
+            if (!TextUtils.isEmpty(getUserKey())) {
+                json.put("userKey", getUserKey());
+            }
             if (!TextUtils.isEmpty(getUserId())) {
                 json.put("userId", getUserId());
             }
@@ -261,6 +270,7 @@ public abstract class BaseEvent extends GEvent {
         private String mPlatform;
         private String mPlatformVersion;
         private String mDeviceId;
+        private String mUserKey;
         private String mUserId;
         protected String mSessionId;
         protected String mEventType;
@@ -301,6 +311,7 @@ public abstract class BaseEvent extends GEvent {
             mTimestamp = (mTimestamp != 0) ? mTimestamp : System.currentTimeMillis();
             mDeviceId = DeviceInfoProvider.get().getDeviceId();
             mSessionId = PersistentDataProvider.get().getSessionId();
+            mUserKey = UserInfoProvider.get().getLoginUserKey();
             mUserId = UserInfoProvider.get().getLoginUserId();
             EventSequenceId sequenceId = PersistentDataProvider.get().getAndIncrement(mEventType);
             mGlobalSequenceId = sequenceId.getGlobalId();

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/IDataSharer.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/IDataSharer.java
@@ -19,6 +19,7 @@ package com.growingio.android.sdk.track.ipc;
 import androidx.annotation.Nullable;
 
 import java.util.List;
+import java.util.Map;
 
 public interface IDataSharer {
     @Nullable
@@ -35,6 +36,8 @@ public interface IDataSharer {
     List<Integer> getIntArray(String key, List<Integer> defValue);
 
     void putString(String key, @Nullable String value);
+
+    void putMultiString(Map<String, String> values);
 
     void putInt(String key, int value);
 

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/providers/ProviderTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/providers/ProviderTest.java
@@ -154,5 +154,4 @@ public class ProviderTest {
         Truth.assertThat(PersistentDataProvider.get().getDeviceId()).isNotEmpty();
     }
 
-
 }


### PR DESCRIPTION
1. userKey字段, 存储逻辑与userId相同, 即设置后除非用户主动置null, 否则持久化在本地
2. cleanLoginUserId方法调用时, 会同时清除userKey
3. 调用原先的setLoginUserId(String userId)方法时, 等价于调用setLoginUserId(null, userId)
4. userKey于userId均在设置后所有事件中携带上报
5. userKey改变不会触发事件重发逻辑, userId触发事件重发逻辑保持不变
6. 如果userKey或者userId存在不合法, 直接返回
7. 如果userId为null, 则直接设置userKey与userId均为null