### PR TITLE
fix: resend时vst的timestamp可能为0

### DIFF
--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/SessionProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/SessionProvider.java
@@ -96,6 +96,9 @@ public class SessionProvider implements IActivityLifecycle, OnUserIdChangedListe
 
     @TrackThread
     public void resendVisit() {
+        if (mLatestVisitTime == 0) {
+            mLatestVisitTime = System.currentTimeMillis();
+        }
         generateVisit(getSessionId(), mLatestVisitTime);
     }
 


### PR DESCRIPTION
在Application#onCreate初始化完成后调用setLoginUserId/setLocation触发resendVisit导致timestamp为0