### PR TITLE
fix: 区分support包

### DIFF
--- a/demos/demo/src/androidTest/java/com/growingio/autotest/autotracker/PageAttributesEventsTest.java
+++ b/demos/demo/src/androidTest/java/com/growingio/autotest/autotracker/PageAttributesEventsTest.java
@@ -127,7 +127,7 @@ public class PageAttributesEventsTest extends EventsTest {
         getEventsApiServer().setOnReceivedEventListener(eventsListener);
         FragmentLifecycleMonitor.get().addLifecycleCallback((fragment, stage) -> {
             if (fragment.getClass() == PlaceholderFragment.class && stage == FragmentLifecycleCallback.Stage.CREATED) {
-                GrowingAutotracker.get().setPageAttributes(fragment, TEST_ATTRIBUTES);
+                GrowingAutotracker.get().setPageAttributesSupport(fragment, TEST_ATTRIBUTES);
             }
         });
 
@@ -152,7 +152,7 @@ public class PageAttributesEventsTest extends EventsTest {
         getEventsApiServer().setOnReceivedEventListener(eventsListener);
         FragmentLifecycleMonitor.get().addLifecycleCallback((fragment, stage) -> {
             if (fragment.getClass() == PlaceholderFragment.class && stage == FragmentLifecycleCallback.Stage.RESUMED) {
-                TrackHelper.postToUiThread(() -> GrowingAutotracker.get().setPageAttributes(fragment, TEST_ATTRIBUTES));
+                TrackHelper.postToUiThread(() -> GrowingAutotracker.get().setPageAttributesSupport(fragment, TEST_ATTRIBUTES));
             }
         });
 
@@ -237,7 +237,7 @@ public class PageAttributesEventsTest extends EventsTest {
         getEventsApiServer().setOnReceivedEventListener(eventsListener);
         FragmentLifecycleMonitor.get().addLifecycleCallback((fragment, stage) -> {
             if (fragment.getClass() == GreenFragment.class && stage == FragmentLifecycleCallback.Stage.CREATED) {
-                GrowingAutotracker.get().setPageAttributes(fragment, TEST_ATTRIBUTES);
+                GrowingAutotracker.get().setPageAttributesSupport(fragment, TEST_ATTRIBUTES);
             }
         });
 
@@ -264,7 +264,7 @@ public class PageAttributesEventsTest extends EventsTest {
         getEventsApiServer().setOnReceivedEventListener(eventsListener);
         FragmentLifecycleMonitor.get().addLifecycleCallback((fragment, stage) -> {
             if (fragment.getClass() == GreenFragment.class && stage == FragmentLifecycleCallback.Stage.RESUMED) {
-                TrackHelper.postToUiThread(() -> GrowingAutotracker.get().setPageAttributes(fragment, TEST_ATTRIBUTES));
+                TrackHelper.postToUiThread(() -> GrowingAutotracker.get().setPageAttributesSupport(fragment, TEST_ATTRIBUTES));
             }
         });
 

--- a/demos/demo/src/androidTest/java/com/growingio/autotest/autotracker/PageEventsTest.java
+++ b/demos/demo/src/androidTest/java/com/growingio/autotest/autotracker/PageEventsTest.java
@@ -141,7 +141,7 @@ public class PageEventsTest extends EventsTest {
 
         FragmentLifecycleCallback fragmentLifecycleCallback = (fragment, stage) -> {
             if (stage == FragmentLifecycleCallback.Stage.CREATED && fragment.getClass() == GreenFragment.class) {
-                GrowingAutotracker.get().ignorePage(fragment, IgnorePolicy.IGNORE_SELF);
+                GrowingAutotracker.get().ignorePageSupport(fragment, IgnorePolicy.IGNORE_SELF);
             }
         };
         FragmentLifecycleMonitor.get().addLifecycleCallback(fragmentLifecycleCallback);
@@ -183,7 +183,7 @@ public class PageEventsTest extends EventsTest {
 
         FragmentLifecycleCallback fragmentLifecycleCallback = (fragment, stage) -> {
             if (stage == FragmentLifecycleCallback.Stage.CREATED && fragment.getClass() == GreenFragment.class) {
-                GrowingAutotracker.get().ignorePage(fragment, IgnorePolicy.IGNORE_CHILD);
+                GrowingAutotracker.get().ignorePageSupport(fragment, IgnorePolicy.IGNORE_CHILD);
             }
         };
         FragmentLifecycleMonitor.get().addLifecycleCallback(fragmentLifecycleCallback);
@@ -219,7 +219,7 @@ public class PageEventsTest extends EventsTest {
 
         FragmentLifecycleCallback fragmentLifecycleCallback = (fragment, stage) -> {
             if (stage == FragmentLifecycleCallback.Stage.CREATED && fragment.getClass() == GreenFragment.class) {
-                GrowingAutotracker.get().ignorePage(fragment, IgnorePolicy.IGNORE_ALL);
+                GrowingAutotracker.get().ignorePageSupport(fragment, IgnorePolicy.IGNORE_ALL);
             }
         };
         FragmentLifecycleMonitor.get().addLifecycleCallback(fragmentLifecycleCallback);
@@ -276,7 +276,7 @@ public class PageEventsTest extends EventsTest {
 
         FragmentLifecycleCallback fragmentLifecycleCallback = (fragment, stage) -> {
             if (stage == FragmentLifecycleCallback.Stage.CREATED && fragment.getClass() == GreenFragment.class) {
-                GrowingAutotracker.get().setPageAlias(fragment, "TestGreenPage");
+                GrowingAutotracker.get().setPageAliasSupport(fragment, "TestGreenPage");
             }
         };
         FragmentLifecycleMonitor.get().addLifecycleCallback(fragmentLifecycleCallback);

--- a/demos/demo/src/androidTest/java/com/growingio/autotest/autotracker/ViewClickEventsTest.java
+++ b/demos/demo/src/androidTest/java/com/growingio/autotest/autotracker/ViewClickEventsTest.java
@@ -514,7 +514,7 @@ public class ViewClickEventsTest extends EventsTest {
         ));
         FragmentLifecycleMonitor.get().addLifecycleCallback((fragment, stage) -> {
             if (fragment.getClass() == RedFragment.class && stage == FragmentLifecycleCallback.Stage.CREATED) {
-                GrowingAutotracker.get().ignorePage(fragment, IgnorePolicy.IGNORE_SELF);
+                GrowingAutotracker.get().ignorePageSupport(fragment, IgnorePolicy.IGNORE_SELF);
             }
         });
         ActivityScenario<NestedFragmentActivity> scenario = ActivityScenario.launch(NestedFragmentActivity.class);
@@ -538,7 +538,7 @@ public class ViewClickEventsTest extends EventsTest {
         ));
         FragmentLifecycleMonitor.get().addLifecycleCallback((fragment, stage) -> {
             if (fragment.getClass() == GreenFragment.class && stage == FragmentLifecycleCallback.Stage.CREATED) {
-                GrowingAutotracker.get().ignorePage(fragment, IgnorePolicy.IGNORE_CHILD);
+                GrowingAutotracker.get().ignorePageSupport(fragment, IgnorePolicy.IGNORE_CHILD);
             }
         });
         ActivityScenario<NestedFragmentActivity> scenario = ActivityScenario.launch(NestedFragmentActivity.class);

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/Autotracker.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/Autotracker.java
@@ -66,35 +66,36 @@ public class Autotracker extends Tracker {
         });
     }
 
-    public void trackCustomEvent(String eventName, Activity page) {
+    // TODO: 用户cstm事件不关联page，可扩展通过特定API发送的cstm事件支持p字段(通过private隐藏相关方法)
+    private void trackCustomEvent(String eventName, Activity page) {
 
     }
 
-    public void trackCustomEvent(String eventName, Fragment page) {
+    private void trackCustomEvent(String eventName, Fragment page) {
 
     }
 
-    public void trackCustomEvent(String eventName, android.support.v4.app.Fragment page) {
+    private void trackCustomEventSupport(String eventName, android.support.v4.app.Fragment page) {
 
     }
 
-    public void trackCustomEventX(String eventName, androidx.fragment.app.Fragment page) {
+    private void trackCustomEventX(String eventName, androidx.fragment.app.Fragment page) {
 
     }
 
-    public void trackCustomEvent(String eventName, Map<String, String> attributes, Activity page) {
+    private void trackCustomEvent(String eventName, Map<String, String> attributes, Activity page) {
 
     }
 
-    public void trackCustomEvent(String eventName, Map<String, String> attributes, Fragment page) {
+    private void trackCustomEvent(String eventName, Map<String, String> attributes, Fragment page) {
 
     }
 
-    public void trackCustomEvent(String eventName, Map<String, String> attributes, android.support.v4.app.Fragment page) {
+    private void trackCustomEventSupport(String eventName, Map<String, String> attributes, android.support.v4.app.Fragment page) {
 
     }
 
-    public void trackCustomEventX(String eventName, Map<String, String> attributes, androidx.fragment.app.Fragment page) {
+    private void trackCustomEventX(String eventName, Map<String, String> attributes, androidx.fragment.app.Fragment page) {
 
     }
 
@@ -122,7 +123,7 @@ public class Autotracker extends Tracker {
         });
     }
 
-    public void setPageAttributes(final android.support.v4.app.Fragment page, final Map<String, String> attributes) {
+    public void setPageAttributesSupport(final android.support.v4.app.Fragment page, final Map<String, String> attributes) {
         if (!isInited) return;
         if (page == null || attributes == null || attributes.isEmpty()) {
             Logger.e(TAG, "page or attributes is NULL");
@@ -205,7 +206,7 @@ public class Autotracker extends Tracker {
         });
     }
 
-    public void setPageAlias(final android.support.v4.app.Fragment page, final String alias) {
+    public void setPageAliasSupport(final android.support.v4.app.Fragment page, final String alias) {
         if (!isInited) return;
         if (page == null || TextUtils.isEmpty(alias)) {
             Logger.e(TAG, "fragment or alias is NULL");
@@ -261,7 +262,7 @@ public class Autotracker extends Tracker {
         });
     }
 
-    public void ignorePage(final android.support.v4.app.Fragment page, final IgnorePolicy policy) {
+    public void ignorePageSupport(final android.support.v4.app.Fragment page, final IgnorePolicy policy) {
         if (!isInited) return;
         if (page == null || policy == null) {
             Logger.e(TAG, "fragment or policy is NULL");

--- a/growingio-autotracker-core/src/test/java/com/growingio/android/sdk/autotrack/AutotrackTest.java
+++ b/growingio-autotracker-core/src/test/java/com/growingio/android/sdk/autotrack/AutotrackTest.java
@@ -19,7 +19,6 @@ package com.growingio.android.sdk.autotrack;
 
 import android.app.Application;
 import android.app.Fragment;
-import android.content.Intent;
 
 import androidx.test.core.app.ApplicationProvider;
 
@@ -27,7 +26,6 @@ import com.google.common.truth.Truth;
 import com.growingio.android.sdk.Configurable;
 import com.growingio.android.sdk.CoreConfiguration;
 import com.growingio.android.sdk.autotrack.impression.ImpressionProvider;
-import com.growingio.android.sdk.autotrack.inject.ActivityInjector;
 import com.growingio.android.sdk.track.providers.ConfigurationProvider;
 
 import org.junit.Before;
@@ -52,19 +50,6 @@ public class AutotrackTest {
         Map<Class<? extends Configurable>, Configurable> modules = new HashMap<>();
         modules.put(AutotrackConfig.class, new AutotrackConfig().setImpressionScale(0.5f));
         ConfigurationProvider.initWithConfig(new CoreConfiguration("test", "test"), modules);
-    }
-
-
-    @Test
-    public void emptyApiTest() {
-        RobolectricActivity activity = Robolectric.buildActivity(RobolectricActivity.class).get();
-        ActivityInjector.onActivityNewIntent(activity, new Intent());
-        autotracker.trackCustomEvent("custom", activity);
-        autotracker.trackCustomEvent("custom", new HashMap<>(), activity);
-        autotracker.trackCustomEvent("custom", new Fragment());
-        autotracker.trackCustomEvent("custom", new HashMap<>(), new Fragment());
-        autotracker.trackCustomEventX("custom", new androidx.fragment.app.Fragment());
-        autotracker.trackCustomEventX("custom", new HashMap<>(), new androidx.fragment.app.Fragment());
     }
 
     @Test


### PR DESCRIPTION
在android.enableJetifier=false并且没有依赖support包的情况下, 直接调用trackCustomEvent异常的问题
增加TODO: 用户关联cstm和page相关功能未实现