### PR TITLE
fix: 多进程问题

### DIFF
--- a/demos/demo/src/androidTest/java/com/growingio/autotest/tracker/SessionEventsTest.java
+++ b/demos/demo/src/androidTest/java/com/growingio/autotest/tracker/SessionEventsTest.java
@@ -34,7 +34,6 @@ import com.gio.test.three.MainActivity;
 import com.google.common.truth.Truth;
 import com.growingio.android.sdk.autotrack.GrowingAutotracker;
 import com.growingio.android.sdk.track.BuildConfig;
-import com.growingio.android.sdk.track.data.PersistentDataProvider;
 import com.growingio.android.sdk.track.providers.ConfigurationProvider;
 import com.growingio.autotest.EventsTest;
 import com.growingio.autotest.TestTrackConfiguration;
@@ -406,7 +405,6 @@ public class SessionEventsTest extends EventsTest {
     public void forceReissueVisitEventTest() {
         final AtomicBoolean receivedVisit = new AtomicBoolean(false);
         final AtomicBoolean receivedCustom = new AtomicBoolean(false);
-        String oldSessionId = PersistentDataProvider.get().getSessionId();
         getEventsApiServer().setOnReceivedEventListener(new MockEventsApiServer.OnReceivedEventListener() {
             @Override
             protected void onReceivedVisitEvents(JSONArray jsonArray) throws JSONException {
@@ -414,7 +412,6 @@ public class SessionEventsTest extends EventsTest {
                 JSONObject visit = jsonArray.getJSONObject(0);
                 mSessionId = visit.getString("sessionId");
                 Truth.assertThat(mSessionId).isNotEmpty();
-                Truth.assertThat(oldSessionId).isNotEqualTo(mSessionId);
                 receivedVisit.set(true);
             }
 

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/TrackMainThread.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/TrackMainThread.java
@@ -24,6 +24,7 @@ import android.support.annotation.NonNull;
 
 import com.growingio.android.sdk.CoreConfiguration;
 import com.growingio.android.sdk.TrackerContext;
+import com.growingio.android.sdk.track.data.PersistentDataProvider;
 import com.growingio.android.sdk.track.events.EventBuildInterceptor;
 import com.growingio.android.sdk.track.events.helper.EventExcludeFilter;
 import com.growingio.android.sdk.track.events.base.BaseEvent;
@@ -111,10 +112,9 @@ public final class TrackMainThread extends ListenerContainer<OnTrackMainInitSDKC
                 }
 
                 if (ConfigurationProvider.core().isDataCollectionEnabled()) {
-                    if (!SessionProvider.get().createdSession()) {
-                        SessionProvider.get().forceReissueVisit();
+                    if (!PersistentDataProvider.get().isSendVisitAfterRefreshSessionId()) {
+                        SessionProvider.get().generateVisit();
                     }
-
                     onGenerateGEvent(eventBuilder);
                 }
             }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/base/BaseEvent.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/base/BaseEvent.java
@@ -300,7 +300,7 @@ public abstract class BaseEvent extends GEvent {
         public void readPropertyInTrackThread() {
             mTimestamp = (mTimestamp != 0) ? mTimestamp : System.currentTimeMillis();
             mDeviceId = DeviceInfoProvider.get().getDeviceId();
-            mSessionId = SessionProvider.get().getSessionId();
+            mSessionId = PersistentDataProvider.get().getSessionId();
             mUserId = UserInfoProvider.get().getLoginUserId();
             EventSequenceId sequenceId = PersistentDataProvider.get().getAndIncrement(mEventType);
             mGlobalSequenceId = sequenceId.getGlobalId();

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/IDataSharer.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/IDataSharer.java
@@ -18,6 +18,8 @@ package com.growingio.android.sdk.track.ipc;
 
 import androidx.annotation.Nullable;
 
+import java.util.List;
+
 public interface IDataSharer {
     @Nullable
     String getString(String key, @Nullable String defValue);
@@ -30,6 +32,8 @@ public interface IDataSharer {
 
     boolean getBoolean(String key, boolean defValue);
 
+    List<Integer> getIntArray(String key, List<Integer> defValue);
+
     void putString(String key, @Nullable String value);
 
     void putInt(String key, int value);
@@ -40,7 +44,17 @@ public interface IDataSharer {
 
     void putBoolean(String key, boolean value);
 
-    long getAndIncrement(String key, long startValue);
+    void putIntArray(String key, List<Integer> value);
 
-    long getAndAdd(String key, long delta, long startValue);
+    long getAndIncrementLong(String key, long startValue);
+
+    long getAndAddLong(String key, long delta, long startValue);
+
+    int getAndIncrementInt(String key, int startValue);
+
+    int getAndAddInt(String key, int delta, int startValue);
+
+    int getAndDecrementInt(String key, int startValue);
+
+    int getAndDelInt(String key, int delta, int startValue);
 }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/ProcessLock.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/ProcessLock.java
@@ -73,6 +73,23 @@ public class ProcessLock {
         }
     }
 
+    public void lockedRun(Runnable runnable) {
+        if (mFileLock == null) {
+            try {
+                if (mOutputStream == null || mFileChannel == null) {
+                    mOutputStream = mContext.openFileOutput(mName, Context.MODE_PRIVATE);
+                    mFileChannel = mOutputStream.getChannel();
+                }
+                mFileLock = mFileChannel.lock();
+                runnable.run();
+            } catch (Exception ignored) {
+            } finally {
+                release();
+            }
+        }
+
+    }
+
     public void release() {
         try {
             internalRelease();

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/IpcTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/IpcTest.java
@@ -59,7 +59,7 @@ public class IpcTest {
         Truth.assertThat(dataSharer.getFloat("key3", 0)).isEqualTo(1245434.54343F);
         Truth.assertThat(dataSharer.getLong("key4", 0L)).isEqualTo(124543454343L);
         Truth.assertThat(dataSharer.getString("key11", "error")).isEqualTo("error");
-        Truth.assertThat(dataSharer.getAndAdd("key4", 10, 0)).isEqualTo(124543454353L);
+        Truth.assertThat(dataSharer.getAndAddLong("key4", 10, 0L)).isEqualTo(124543454353L);
     }
 
     @Test

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/providers/ProviderTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/providers/ProviderTest.java
@@ -154,29 +154,5 @@ public class ProviderTest {
         Truth.assertThat(PersistentDataProvider.get().getDeviceId()).isNotEmpty();
     }
 
-    @Test
-    public void sessionProvider() {
-        String sessionId = SessionProvider.get().getSessionId();
-        Truth.assertThat(sessionId).isEmpty();
-        SessionProvider.get().checkAndSendVisit(0);
-        sessionId = SessionProvider.get().getSessionId();
-        Truth.assertThat(sessionId).isEmpty();
-        SessionProvider.get().setLocation(0d, 1d);
-        Truth.assertThat(SessionProvider.get().getLatitude()).isEqualTo(0d);
-        Truth.assertThat(SessionProvider.get().getLongitude()).isEqualTo(1d);
-        SessionProvider.get().cleanLocation();
-
-        SessionProvider.get().onTrackMainInitSDK();
-        UserInfoProvider.get().setLoginUserId("cpacm");
-        String newSessionId1 = SessionProvider.get().refreshSessionId();
-        String newSessionId2 = SessionProvider.get().getSessionId();
-        Truth.assertThat(newSessionId1).isEqualTo(newSessionId2);
-
-        UserInfoProvider.get().setLoginUserId("cpacm2");
-        String newSessionId3 = SessionProvider.get().getSessionId();
-        Truth.assertThat(newSessionId3).isNotEqualTo(newSessionId2);
-        UserInfoProvider.get().unregisterUserIdChangedListener(SessionProvider.get());
-    }
-
 
 }


### PR DESCRIPTION
多进程session改变逻辑:

主进程设置用户A - 子进程设置用户B - 主进程设置用户A 触发session改变 发送vst
主进程初始化发送 改变session vst, 子进程发送vst但是使用相同session

disable -> enable 一定会触发发送vst, 但是不会改变session
多进程的datacollect开关相互独立, 但是session共享

统一思想: 
整个应用初始化时只会改变一次session, 发送vst仅在session改变 或者调用enable(开关不会导致session发生变化)
不管子进程还是主进程, 刷新session的逻辑只有如下两个场景:
1. 用户发生改变
2. 后台30s