### PR TITLE
fix: memory leak

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ buildscript {
         ]
 
         releaseConfiguration = [
-                releaseVersion    : "3.2.1",
-                releaseVersionCode: 30201,
+                releaseVersion    : "3.2.2-09041-SNAPSHOT",
+                releaseVersionCode: 30202,
         ]
 
         versions = [

--- a/demos/demo/build.gradle
+++ b/demos/demo/build.gradle
@@ -104,6 +104,9 @@ dependencies {
     implementation project(":demo-autotrack")
 
     compileOnly libraries.androidx.appcompat
+
+    // leakcanary 避免发版前未使用Profiler进行内存泄漏检测
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.7'
 }
 
 apply from: "${rootProject.projectDir}/gradle/jacoco.gradle"

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/SuperFragment.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/SuperFragment.java
@@ -23,18 +23,11 @@ import android.view.View;
 
 import androidx.annotation.Nullable;
 
-import java.util.Map;
-import java.util.WeakHashMap;
-
 public abstract class SuperFragment<T> {
     private final T mRealFragment;
 
-    //将SuperFragment对象和Fragment对象产生关联，防止GC后SuperFragment对象被释放，保证SuperFragment对象和Fragment对象生命周期一致
-    private static final Map<Object, SuperFragment<?>> ASSOCIATION_OBJECTS = new WeakHashMap<>();
-
     protected SuperFragment(T realFragment) {
         mRealFragment = realFragment;
-        ASSOCIATION_OBJECTS.put(mRealFragment, this);
     }
 
     @Nullable


### PR DESCRIPTION
SuperFragment会被ActivityPage持有, 不会在GC时自动回收, ASSOCIATE中SuperFragment持有了Frament的引用, 即导致WeakHashmap中value持有了key的引用, 引发内存泄漏
SuperFragment在demo中不会在GC时自动回收的原因:
1. SuperFragment会被ActivityPage持有, 只要不DestroyView, 就会一直被持有
2. ViewPage的场景, onDestroyView触发后, 在onCreate中设置类似Ignore的SuperFragment此时会被Fragment持有的mView持有, 因为设置了setTag, 然后又被ViewModel持有, 所以与Fragment保持了相同生命周期

复现:
1. 进入无埋点测试->进入NestedFragmentActivity->通过Profile分析, 选择Show activity/fragment Leaks
2. 进入无埋点测试->进入TabFragmentActivity->注释ViewModel相关内容, onCreate中设置Ignore,  切换到Tab5强制GC, 切回Tab1, 发送了Tab1的page(此时SuperFragment被回收, Igore或者Alias设置失效)

测试: 
1. 进入无埋点测试->进入NestedFragmentActivity->通过Profile分析SuperFragment$V4Fragment引用链
2. 进入无埋点测试->进入NestedFragmentActivity->退出NestedFragmentActivity->强制GC, 查看SuperFragment$V4Fragment是否被回收
3. 进入无埋点测试->进入TabFragmentActivity->退出TabFragmentActivity->强制GC, 切换tab, 查看SuperFragment$V4Fragment是否被回收

功能回归:
1. fragment page是否正常发送
2. ignorePage相关功能是否正常
3. setPageAlias相关功能是否正常

注意:
1. SuperFragment已经重写了hashcode以及equals方法, 所以可以直接创建新的对象