### PR TITLE
optimize: 删除冗余判断

### DIFF
--- a/demos/demo-autotrack/src/main/java/com/gio/test/three/autotrack/activity/ui/main/PlaceholderFragment.java
+++ b/demos/demo-autotrack/src/main/java/com/gio/test/three/autotrack/activity/ui/main/PlaceholderFragment.java
@@ -87,7 +87,7 @@ public class PlaceholderFragment extends BaseFragment {
             Bundle savedInstanceState) {
         View root = inflater.inflate(R.layout.fragment_tab, container, false);
         final TextView textView = root.findViewById(R.id.section_label);
-        mPageViewModel.getText().observe(this, new Observer<String>() {
+        mPageViewModel.getText().observe(this.getViewLifecycleOwner(), new Observer<String>() {
             @Override
             public void onChanged(@Nullable String s) {
                 textView.setText(s);

--- a/gio-sdk/autotracker-cdp/src/main/java/com/growingio/android/sdk/autotrack/CdpAutotracker.java
+++ b/gio-sdk/autotracker-cdp/src/main/java/com/growingio/android/sdk/autotrack/CdpAutotracker.java
@@ -17,6 +17,7 @@
 package com.growingio.android.sdk.autotrack;
 
 import android.app.Application;
+import android.support.annotation.CallSuper;
 import android.text.TextUtils;
 
 import com.growingio.android.sdk.track.TrackMainThread;
@@ -34,6 +35,12 @@ public class CdpAutotracker extends Autotracker {
 
     public CdpAutotracker(Application application) {
         super(application);
+    }
+
+    @Override
+    @CallSuper
+    protected void setup(Application application) {
+        super.setup(application);
         CdpAutotrackConfig config = ConfigurationProvider.get().getConfiguration(CdpAutotrackConfig.class);
         if (config != null) {
             TrackMainThread.trackMain().addEventBuildInterceptor(new CdpEventBuildInterceptor(config.getDataSourceId()));

--- a/gio-sdk/tracker-cdp/src/main/java/com/growingio/android/sdk/track/CdpTracker.java
+++ b/gio-sdk/tracker-cdp/src/main/java/com/growingio/android/sdk/track/CdpTracker.java
@@ -19,6 +19,8 @@ package com.growingio.android.sdk.track;
 import android.app.Application;
 import android.text.TextUtils;
 
+import androidx.annotation.CallSuper;
+
 import com.growingio.android.sdk.Tracker;
 import com.growingio.android.sdk.track.cdp.CdpEventBuildInterceptor;
 import com.growingio.android.sdk.track.cdp.ResourceItem;
@@ -34,6 +36,12 @@ public class CdpTracker extends Tracker {
 
     public CdpTracker(Application application) {
         super(application);
+    }
+
+    @Override
+    @CallSuper
+    protected void setup(Application application) {
+        super.setup(application);
         CdpConfig cdpConfig = ConfigurationProvider.get().getConfiguration(CdpConfig.class);
         if (cdpConfig != null) {
             TrackMainThread.trackMain().addEventBuildInterceptor(new CdpEventBuildInterceptor(cdpConfig.getDataSourceId()));

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/Autotracker.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/Autotracker.java
@@ -19,6 +19,7 @@ package com.growingio.android.sdk.autotrack;
 import android.app.Activity;
 import android.app.Application;
 import android.app.Fragment;
+import android.support.annotation.CallSuper;
 import android.text.TextUtils;
 import android.view.View;
 
@@ -40,13 +41,16 @@ public class Autotracker extends Tracker {
 
     public Autotracker(Application application) {
         super(application);
-        if (application == null) {
-            return;
-        }
-        PageProvider.get().start();
+    }
+
+    @Override
+    @CallSuper
+    protected void setup(Application application) {
+        super.setup(application);
+        PageProvider.get().setup();
         ViewChangeProvider mViewChangeProvider;
         mViewChangeProvider = new ViewChangeProvider();
-        mViewChangeProvider.start();
+        mViewChangeProvider.setup();
 
         TrackerContext.initSuccess();
     }

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/change/ViewChangeProvider.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/change/ViewChangeProvider.java
@@ -43,7 +43,7 @@ public class ViewChangeProvider implements IActivityLifecycle, OnViewStateChange
     public ViewChangeProvider() {
     }
 
-    public void start() {
+    public void setup() {
         ActivityStateProvider.get().registerActivityLifecycleListener(this);
         ViewTreeStatusProvider.get().register(this);
     }

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/PageProvider.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/PageProvider.java
@@ -60,7 +60,7 @@ public class PageProvider implements IActivityLifecycle {
         return SingleInstance.INSTANCE;
     }
 
-    public void start() {
+    public void setup() {
         ActivityStateProvider.get().registerActivityLifecycleListener(this);
     }
 

--- a/growingio-autotracker-core/src/test/java/com/growingio/android/sdk/autotrack/page/PageTest.java
+++ b/growingio-autotracker-core/src/test/java/com/growingio/android/sdk/autotrack/page/PageTest.java
@@ -59,7 +59,7 @@ public class PageTest {
         application.registerActivityLifecycleCallbacks(ActivityStateProvider.get());
         TrackerContext.init(application);
         TrackerContext.initSuccess();
-        PageProvider.get().start();
+        PageProvider.get().setup();
         SessionProvider.get();
         activityController = Robolectric.buildActivity(RobolectricActivity.class);
     }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
@@ -71,18 +71,13 @@ public class Tracker {
         // init core service
         application.registerActivityLifecycleCallbacks(ActivityStateProvider.get());
         DeepLinkProvider.get().init();
+        SessionProvider.get().init();
 
         loadAnnotationGeneratedModules(application);
     }
 
     private void start() {
-        TrackMainThread.trackMain().postActionToTrackMain(new Runnable() {
-            @Override
-            public void run() {
-                // 判断进程是否是首次启动, 耗时操作放到子线程中执行
-                PersistentDataProvider.get().start();
-            }
-        });
+        PersistentDataProvider.get().start();
     }
 
 

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/TrackMainThread.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/TrackMainThread.java
@@ -106,12 +106,12 @@ public final class TrackMainThread extends ListenerContainer<OnTrackMainInitSDKC
                     return;
                 }
 
-                // 判断当前事件类型是否被过滤
-                if (EventExcludeFilter.isEventFilter(eventBuilder.getEventType())) {
-                    return;
-                }
-
                 if (ConfigurationProvider.core().isDataCollectionEnabled()) {
+                    // 判断当前事件类型是否被过滤
+                    if (EventExcludeFilter.isEventFilter(eventBuilder.getEventType())) {
+                        return;
+                    }
+
                     if (!PersistentDataProvider.get().isSendVisitAfterRefreshSessionId()) {
                         SessionProvider.get().generateVisit();
                     }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/cdp/CdpEventBuildInterceptor.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/cdp/CdpEventBuildInterceptor.java
@@ -20,7 +20,6 @@ import android.text.TextUtils;
 
 import androidx.annotation.Nullable;
 
-import com.growingio.android.sdk.track.TrackMainThread;
 import com.growingio.android.sdk.track.data.PersistentDataProvider;
 import com.growingio.android.sdk.track.events.EventBuildInterceptor;
 import com.growingio.android.sdk.track.events.base.BaseEvent;
@@ -35,22 +34,16 @@ public class CdpEventBuildInterceptor implements EventBuildInterceptor, OnUserId
     private static final String KEY_GIO_ID = "GIO_ID";
 
     private final String mDataSourceId;
-    private String mLatestGioId;
 
     public CdpEventBuildInterceptor(String dataSourceId) {
         mDataSourceId = dataSourceId;
         UserInfoProvider.get().registerUserIdChangedListener(this);
-        TrackMainThread.trackMain().postActionToTrackMain(new Runnable() {
-            @Override
-            public void run() {
-                mLatestGioId = getGioId();
-            }
-        });
     }
 
     @Override
     public void eventWillBuild(BaseEvent.BaseBuilder<?> eventBuilder) {
         eventBuilder.addExtraParam("dataSourceId", mDataSourceId);
+        String mLatestGioId = getGioId();
         if (!TextUtils.isEmpty(mLatestGioId)) {
             eventBuilder.addExtraParam("gioId", mLatestGioId);
         }
@@ -71,10 +64,10 @@ public class CdpEventBuildInterceptor implements EventBuildInterceptor, OnUserId
 
     @Override
     public void onUserIdChanged(@Nullable String newUserId) {
+        String mLatestGioId = getGioId();
         Logger.d(TAG, "onUserIdChanged: newUserId = " + newUserId + ", mLatestGioId = " + mLatestGioId);
         if (!TextUtils.isEmpty(newUserId) && !newUserId.equals(mLatestGioId)) {
-            mLatestGioId = newUserId;
-            setGioId(mLatestGioId);
+            setGioId(newUserId);
         }
     }
 }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/data/PersistentDataProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/data/PersistentDataProvider.java
@@ -170,10 +170,11 @@ public class PersistentDataProvider {
 
                 if (alivePid.isEmpty()) {
                     setActivityCount(0);
-                    SessionProvider.get().refreshSessionId();
-                    SessionProvider.get().generateVisit();
                     setLatestPauseTime(System.currentTimeMillis());
                     setLatestNonNullUserId(getLoginUserId());
+
+                    SessionProvider.get().refreshSessionId();
+                    SessionProvider.get().generateVisit();
                 }
 
                 alivePid.add(Process.myPid());

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/data/PersistentDataProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/data/PersistentDataProvider.java
@@ -169,10 +169,10 @@ public class PersistentDataProvider {
                 }
 
                 if (alivePid.isEmpty()) {
+                    setActivityCount(0);
                     SessionProvider.get().refreshSessionId();
                     SessionProvider.get().generateVisit();
                     setLatestPauseTime(System.currentTimeMillis());
-                    setActivityCount(0);
                     setLatestNonNullUserId(getLoginUserId());
                 }
 

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/SessionProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/SessionProvider.java
@@ -44,6 +44,9 @@ public class SessionProvider implements IActivityLifecycle {
 
     private SessionProvider() {
         mSessionInterval = ConfigurationProvider.core().getSessionInterval() * 1000L;
+    }
+
+    public void init() {
         mActivityList.clear();
         ActivityStateProvider.get().registerActivityLifecycleListener(this);
     }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/UserInfoProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/UserInfoProvider.java
@@ -84,6 +84,7 @@ public class UserInfoProvider extends ListenerContainer<OnUserIdChangedListener,
         listener.onUserIdChanged(action);
     }
 
+    @TrackThread
     private void needSendVisit(String newUserId) {
         String mLatestNonNullUserId = PersistentDataProvider.get().getLatestNonNullUserId();
         Logger.d(TAG, "onUserIdChanged: newUserId = " + newUserId + ", mLatestNonNullUserId = " + mLatestNonNullUserId);

--- a/growingio-webservice/circler/src/main/java/com/growingio/android/circler/CirclerDataLoader.java
+++ b/growingio-webservice/circler/src/main/java/com/growingio/android/circler/CirclerDataLoader.java
@@ -50,7 +50,6 @@ public class CirclerDataLoader implements ModelLoader<Circler, WebService> {
 
     public static class Factory implements ModelLoaderFactory<Circler, WebService> {
         private static volatile OkHttpClient sInternalClient;
-        private final OkHttpClient client;
 
         private static final int DEFAULT_CONNECT_TIMEOUT = 5;
         private static final int DEFAULT_READ_TIMEOUT = 10;
@@ -70,16 +69,11 @@ public class CirclerDataLoader implements ModelLoader<Circler, WebService> {
         }
 
         public Factory() {
-            this(getsInternalClient());
-        }
-
-        public Factory(OkHttpClient client) {
-            this.client = client;
         }
 
         @Override
         public ModelLoader<Circler, WebService> build() {
-            return new CirclerDataLoader(client);
+            return new CirclerDataLoader(getsInternalClient());
         }
     }
 }

--- a/growingio-webservice/debugger/src/main/java/com/growingio/android/debugger/DebuggerDataLoader.java
+++ b/growingio-webservice/debugger/src/main/java/com/growingio/android/debugger/DebuggerDataLoader.java
@@ -46,7 +46,6 @@ public class DebuggerDataLoader implements ModelLoader<Debugger, WebService> {
 
     public static class Factory implements ModelLoaderFactory<Debugger, WebService> {
         private static volatile OkHttpClient sInternalClient;
-        private final OkHttpClient client;
 
         private static final int DEFAULT_CONNECT_TIMEOUT = 5;
         private static final int DEFAULT_READ_TIMEOUT = 10;
@@ -66,16 +65,11 @@ public class DebuggerDataLoader implements ModelLoader<Debugger, WebService> {
         }
 
         public Factory() {
-            this(getsInternalClient());
-        }
-
-        public Factory(OkHttpClient client) {
-            this.client = client;
         }
 
         @Override
         public ModelLoader<Debugger, WebService> build() {
-            return new DebuggerDataLoader(client);
+            return new DebuggerDataLoader(getsInternalClient());
         }
     }
 }


### PR DESCRIPTION
改动点
[✅] 1. postEventToTrackMain中存在判断是否开启采集(isDataCollectionEnabled), 删除多余判断
[✅] 2. 将刷新session移动到判断firstinit的进程锁中, 避免主进程还未刷新session, 子进程发送cstm的场景(从执行上讲, 基本不存在这种场景)
[✅] 3. CdpEventBuildInterceptor中onUserId的回调慢于SessionProvider的onUserId回调 导致事件先于gioId修改发出
[✅] 4. CdpEventBuildInterceptor注册事件拦截晚于业务vst发送, 导致缺失字段
[❌] 5. PersistentProvider 中多进程判断耗时, 转到子线程中执行, 存在问题暂时不进行修改, 在Note 9Pro上初始化耗时在50-70ms之间, 可接受范围内, 暂时不做优化
[✅] 6. 圈选时tipview的内存泄漏并非真正的泄漏, removeView时被leackcanary添加到队列, 然后新的activity#onResume,又重新addView, 此时leakcanary检测view的attachInfo不为null, 认为view泄漏了, 时机推出圈选时tipView可以被回收
[✅] 7. 懒加载debugger和circle的okhttpClient, release环境不需要初始化对应对象
[✅] 8. demo中存在内存泄漏, PlaceholderFragment应该使用this.getViewLifecycleOwner(), 将add/remove与onCreateView/onDestroyView绑定

测试 
1. 断点主进程的refreshSessionId, 子进程调用trackCustomEvent, 此时会复用上一次的session
2. 设置userId, gioId 会使用上一次的userId
3. 冷启动发送的vst不带gioId

遗留问题
1. 合并了cdp和saas, 需要将demo修正为cdp, 因为cdp包含saas场景
2. 测试用例增加多进程测试, 增加StrictMode和LeakCanary
3. 集成测试增加cdp测试用例
5. PersistentProvider转到子线程, 前后台切换存在实际问题, 例: 子线程未将首次启动的activityCount置0, 先走到了Activity#onResume导致activityCount异常