### PR TITLE
fix: 延迟初始化访问导致NPE

### DIFF
--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/inject/WebViewInjector.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/inject/WebViewInjector.java
@@ -31,6 +31,11 @@ public class WebViewInjector {
     private static final String TAG = "WebViewInjector";
 
     private static void bridgeForWebView(View view) {
+        if (!TrackerContext.initializedSuccessfully()) {
+            Logger.e(TAG, "Autotracker do not initialized successfully");
+            return;
+        }
+
         boolean result = false;
         ModelLoader<HybridBridge, Boolean> modelLoader = TrackerContext.get().getRegistry().getModelLoader(HybridBridge.class, Boolean.class);
         if (modelLoader != null) {


### PR DESCRIPTION
复现:
无埋点不初始化SDK, 直接访问带webview的界面, 会引发NPE崩溃

测试:
不初始化无埋点SDK的场景, 可以正常访问界面

