### PR TITLE
fix: webview looper检查

### DIFF
--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/Autotracker.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/Autotracker.java
@@ -23,7 +23,6 @@ import android.support.annotation.CallSuper;
 import android.text.TextUtils;
 import android.view.View;
 
-import com.growingio.android.sdk.TrackerContext;
 import com.growingio.android.sdk.autotrack.change.ViewChangeProvider;
 import com.growingio.android.sdk.autotrack.impression.ImpressionProvider;
 import com.growingio.android.sdk.autotrack.page.PageProvider;
@@ -51,8 +50,6 @@ public class Autotracker extends Tracker {
         ViewChangeProvider mViewChangeProvider;
         mViewChangeProvider = new ViewChangeProvider();
         mViewChangeProvider.setup();
-
-        TrackerContext.initSuccess();
     }
 
     public void setUniqueTag(final View view, final String tag) {

--- a/growingio-hybrid/src/main/java/com/growingio/android/hybrid/HybridBridgeProvider.java
+++ b/growingio-hybrid/src/main/java/com/growingio/android/hybrid/HybridBridgeProvider.java
@@ -21,7 +21,6 @@ import android.os.Build;
 import android.text.TextUtils;
 import android.webkit.ValueCallback;
 
-import com.growingio.android.sdk.TrackerContext;
 import com.growingio.android.sdk.track.SDKConfig;
 import com.growingio.android.sdk.track.async.Callback;
 import com.growingio.android.sdk.track.async.Disposable;
@@ -75,10 +74,6 @@ public class HybridBridgeProvider extends ListenerContainer<OnDomChangedListener
 
     @SuppressLint("SetJavaScriptEnabled")
     public void bridgeForWebView(SuperWebView<?> webView) {
-        if (!TrackerContext.initializedSuccessfully()) {
-            Logger.e(TAG, "Autotracker do not initialized successfully");
-            return;
-        }
         webView.setJavaScriptEnabled(true);
         if (webView.hasAddJavaScripted()) return;
         webView.addJavascriptInterface(new WebViewBridgeJavascriptInterface(getJavascriptBridgeConfiguration()), WebViewBridgeJavascriptInterface.JAVASCRIPT_INTERFACE_NAME);

--- a/growingio-hybrid/src/main/java/com/growingio/android/hybrid/NativeBridge.java
+++ b/growingio-hybrid/src/main/java/com/growingio/android/hybrid/NativeBridge.java
@@ -16,9 +16,7 @@
 
 package com.growingio.android.hybrid;
 
-import com.growingio.android.sdk.TrackerContext;
 import com.growingio.android.sdk.track.TrackMainThread;
-import com.growingio.android.sdk.track.log.Logger;
 import com.growingio.android.sdk.track.providers.UserInfoProvider;
 
 class NativeBridge {
@@ -31,20 +29,10 @@ class NativeBridge {
     }
 
     void dispatchEvent(String event) {
-        if (!TrackerContext.initializedSuccessfully()) {
-            Logger.e(TAG, "Autotracker do not initialized successfully");
-            return;
-        }
-
         TrackMainThread.trackMain().postEventToTrackMain(mHybridTransformer.transform(event));
     }
 
     void setNativeUserId(String userId) {
-        if (!TrackerContext.initializedSuccessfully()) {
-            Logger.e(TAG, "Autotracker do not initialized successfully");
-            return;
-        }
-
         TrackMainThread.trackMain().postActionToTrackMain(new Runnable() {
             @Override
             public void run() {
@@ -54,11 +42,6 @@ class NativeBridge {
     }
 
     void clearNativeUserId() {
-        if (!TrackerContext.initializedSuccessfully()) {
-            Logger.e(TAG, "Autotracker do not initialized successfully");
-            return;
-        }
-
         TrackMainThread.trackMain().postActionToTrackMain(new Runnable() {
             @Override
             public void run() {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
@@ -62,6 +62,7 @@ public class Tracker {
         // 业务逻辑
         start();
 
+        TrackerContext.initSuccess();
         isInited = true;
     }
 

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
@@ -186,7 +186,7 @@ public class Tracker {
     public void bridgeWebView(View webView) {
         if (!isInited) return;
         if (ClassExistHelper.isWebView(webView)) {
-            TrackMainThread.trackMain().postActionToTrackMain(() -> bridgeInnerWebView(webView));
+            bridgeInnerWebView(webView);
         } else {
             Logger.e(TAG, "please check your " + webView.getClass().getName() + "is WebView or com.tencent.smtt.sdk.WebView or com.uc.webview.export.WebView");
         }


### PR DESCRIPTION
复现
在WebViewActivity中调用GrowingAutotracker.get().bridgeWebView(mWebView);崩溃

WebView需要在初始化对象线程中调用, AOS会检查对应looper引发崩溃

测试
回归埋点、无埋点接口调用