### PR TITLE
fix: ci中ndk环境升级

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      - name: Set NDK path
+        run: |
+          echo "ndk.dir=$ANDROID_NDK_HOME" >> local.properties
+
       - name: Before script
         run: |
           chmod +x gradlew


### PR DESCRIPTION
ndk version from 22.1.7171670 to 23.0.7599858(ANDROID_NDK_LATEST_HOME) in macos-latest
The NdkLocator.kt in gradle plugin 3.5.0 will use the highest version
```kotlin
private fun findNdkPathImpl(
    ndkDirProperty: String?,
    androidNdkHomeEnvironmentVariable: String?,
    sdkFolder: File?,
    ndkVersionFromDsl: String?,
    getNdkVersionedFolderNames: (File) -> List<String>, // function that returns the NDK folders under $SDK/ndk
    getNdkSourceProperties: (File) -> SdkSourceProperties?
): File? {
      ...
      // From the existing NDKs find the highest. We'll use this as a fall-back in case there's an
      // error. We still want to succeed the sync and recover as best we can.
      val highest = versionedLocations.firstOrNull()
}

fun findNdkPath(
    ndkVersionFromDsl: String?,
    projectDir: File
): NdkLocatorRecord {
    val properties = gradleLocalProperties(projectDir)
    val sdkPath = SdkLocator.getSdkLocation(projectDir).directory
    return findNdkPathWithRecord(
        ndkVersionFromDsl,
        properties.getProperty(NDK_DIR_PROPERTY),
        System.getenv("ANDROID_NDK_HOME"),
        sdkPath,
        ::getNdkVersionedFolders,
        ::getNdkVersionInfo
    )
}
```
So the environment variable (ANDROID_NDK_HOME) has no effect

try this step:
```yml
- name: Set NDK path
  run: |
    echo "ndk.dir=$ANDROID_NDK_HOME" >> local.properties
```

also in NdkLocator.kt
```kotlin
// If the user requested a specific version then honor it now
if (ndkVersionFromDslRevision != null) {
    // If the user specified ndk.dir then it must be used. It must also match the version
    // supplied in build.gradle.
    if (ndkDirProperty != null) {
        val ndkDirLocation = versionedLocations.find { (location, _) ->
                location.type == NDK_DIR_LOCATION
        }
        if (ndkDirLocation == null) {
            errorln(
                    "Location specified by ndk.dir ($ndkDirProperty) did not contain a " +
                            "valid NDK and so couldn't satisfy the requested NDK version " +
                            "$ndkVersionFromDsl"
            )
        } else {
            val (location, version) = ndkDirLocation
            if (isAcceptableNdkVersion(version.revision, ndkVersionFromDslRevision)) {
                infoln(
                        "Choosing ${location.ndkRoot} from $NDK_DIR_PROPERTY which had the requested " +
                                "version $ndkVersionFromDsl"
                )
            } else {
                errorln(
                        "Requested NDK version $ndkVersionFromDsl did not match the version " +
                                "${version.revision} requested by $NDK_DIR_PROPERTY at ${location.ndkRoot}"
                )
            }
            return location.ndkRoot
        }
    }
}
```