### PR TITLE
fix: menuitem的title如果为null导致npe

### DIFF
--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/view/ViewHelper.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/view/ViewHelper.java
@@ -129,7 +129,7 @@ public class ViewHelper {
         return ViewNode.ViewNodeBuilder.newViewNode()
                 .needRecalculate(false)
                 .setIndex(-1)
-                .setViewContent(menuItem.getTitle().toString())
+                .setViewContent(menuItem.getTitle() != null ? menuItem.getTitle().toString() : null)
                 .setXPath(xpath.toString())
                 .setOriginalXPath(xpath.toString())
                 .setPrefixPage(xpath.toString())


### PR DESCRIPTION
menuitem的title存在为null的场景

测试:
不设置bottom_nav_menu.xml的android:title 
然后启动ToolBarActivity 点击左上角为空的的item导致崩溃