### PR TITLE
fix: 适配中文

### DIFF
--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/SharedEntry.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/SharedEntry.java
@@ -151,12 +151,14 @@ class SharedEntry {
         if (value == null) {
             value = "";
         }
-        if (value.length() > (MAX_SIZE - (mValuePosition - mPosition))) {
+        byte[] valueBytes = value.getBytes();
+        short valueLength = valueBytes == null ? 0 : ((short) valueBytes.length);
+        if (valueLength > (MAX_SIZE - (mValuePosition - mPosition))) {
             throw new IllegalArgumentException("value is too long, value.length() = " + value.length());
         }
-        byteBuffer.putShort((short) value.length());
-        if (value.length() > 0) {
-            byteBuffer.put(value.getBytes());
+        byteBuffer.putShort(valueLength);
+        if (valueLength > 0) {
+            byteBuffer.put(valueBytes);
         }
     }
 


### PR DESCRIPTION
UTF-8编码的byte数组length与String#length获取不同导致乱码

区别为
"测试".length()
"测试".getBytes().length