### PR TITLE
fix:Exposure area calculation problem.

### DIFF
--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/impression/ImpressionProvider.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/impression/ImpressionProvider.java
@@ -116,7 +116,7 @@ public class ImpressionProvider implements OnViewStateChangedListener {
 
             Rect rect = new Rect();
             view.getLocalVisibleRect(rect);
-            return rect.right * rect.bottom >= view.getMeasuredHeight() * view.getMeasuredWidth() * mImpressionScale;
+            return rect.width() * rect.height() >= view.getMeasuredHeight() * view.getMeasuredWidth() * mImpressionScale;
         }
         return false;
     }


### PR DESCRIPTION
经过测试，曝光事件可见区域比例设置某些情况并不能正确工作
经过排查发现控件可见区域计算有些问题：

修改可见区域计算方式：

由：
  rect.right * rect.bottom
替换为：
  rect.width() * rect.height()
