### PR TITLE
fix:网络类型中增加对5g的判断

### DIFF
--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/NetworkUtil.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/NetworkUtil.java
@@ -91,13 +91,15 @@ public class NetworkUtil {
         }
         switch (subType) {
             //如果是2g类型
+            case TelephonyManager.NETWORK_TYPE_GSM:
+            case TelephonyManager.NETWORK_TYPE_CDMA:
             case TelephonyManager.NETWORK_TYPE_GPRS:
             case TelephonyManager.NETWORK_TYPE_EDGE:
             case TelephonyManager.NETWORK_TYPE_1xRTT:
             case TelephonyManager.NETWORK_TYPE_IDEN:
                 return "2G";
             //如果是3g类型
-            case TelephonyManager.NETWORK_TYPE_CDMA:
+            case TelephonyManager.NETWORK_TYPE_TD_SCDMA:
             case TelephonyManager.NETWORK_TYPE_EVDO_A:
             case TelephonyManager.NETWORK_TYPE_UMTS:
             case TelephonyManager.NETWORK_TYPE_EVDO_0:
@@ -110,7 +112,10 @@ public class NetworkUtil {
                 return "3G";
             //如果是4g类型
             case TelephonyManager.NETWORK_TYPE_LTE:
+            case TelephonyManager.NETWORK_TYPE_IWLAN:
                 return "4G";
+            case TelephonyManager.NETWORK_TYPE_NR:
+                return "5G";
             default:
                 //中国移动 联通 电信 三种3G制式
                 if ("TD-SCDMA".equalsIgnoreCase(subtypeName)

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/utils/UtilsTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/utils/UtilsTest.java
@@ -129,8 +129,10 @@ public class UtilsTest {
         Truth.assertThat(state.isMobileData()).isTrue();
         Truth.assertThat(state.isConnected()).isTrue();
         Truth.assertThat(state.getNetworkName()).isEqualTo("2G");
-        Truth.assertThat(NetworkUtil.getNetworkName(ConnectivityManager.TYPE_MOBILE, TelephonyManager.NETWORK_TYPE_CDMA, "Test Network")).isEqualTo("3G");
+        Truth.assertThat(NetworkUtil.getNetworkName(ConnectivityManager.TYPE_MOBILE, TelephonyManager.NETWORK_TYPE_CDMA, "Test Network")).isEqualTo("2G");
+        Truth.assertThat(NetworkUtil.getNetworkName(ConnectivityManager.TYPE_MOBILE, TelephonyManager.NETWORK_TYPE_TD_SCDMA, "Test Network")).isEqualTo("3G");
         Truth.assertThat(NetworkUtil.getNetworkName(ConnectivityManager.TYPE_MOBILE, TelephonyManager.NETWORK_TYPE_LTE, "Test Network")).isEqualTo("4G");
+        Truth.assertThat(NetworkUtil.getNetworkName(ConnectivityManager.TYPE_MOBILE, TelephonyManager.NETWORK_TYPE_NR, "Test Network")).isEqualTo("5G");
         Truth.assertThat(NetworkUtil.getNetworkName(ConnectivityManager.TYPE_WIFI, TelephonyManager.NETWORK_TYPE_LTE, "Test Network")).isEqualTo("WIFI");
     }
 


### PR DESCRIPTION
## PR 内容

1. 增加网络类型对是否为5G的判断

## 测试步骤

1. 使用测试机在5G网络下测试，生成事件中的网络类型显示正确
2. 使用测试机在3G、4G等网络下测试，事件中的网络类型显示正确

## 影响范围

1. 所有生成事件的网络类型(networkState) 字段

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

无
