### PR TITLE
fix: cdp trackCustomEvent add eventName check

### DIFF
--- a/gio-sdk/autotracker-cdp/src/main/java/com/growingio/android/sdk/autotrack/CdpAutotracker.java
+++ b/gio-sdk/autotracker-cdp/src/main/java/com/growingio/android/sdk/autotrack/CdpAutotracker.java
@@ -53,8 +53,8 @@ public class CdpAutotracker extends Autotracker {
 
     public void trackCustomEvent(String eventName, Map<String, String> attributes, String itemKey, String itemId) {
         if (!isInited) return;
-        if (TextUtils.isEmpty(itemKey) || TextUtils.isEmpty(itemId)) {
-            Logger.e(TAG, "trackCustomEvent: itemKey or itemId is NULL");
+        if (TextUtils.isEmpty(eventName) || TextUtils.isEmpty(itemKey) || TextUtils.isEmpty(itemId)) {
+            Logger.e(TAG, "trackCustomEvent: eventName, itemKey or itemId is NULL");
             return;
         }
 

--- a/gio-sdk/tracker-cdp/src/main/java/com/growingio/android/sdk/track/CdpTracker.java
+++ b/gio-sdk/tracker-cdp/src/main/java/com/growingio/android/sdk/track/CdpTracker.java
@@ -54,8 +54,8 @@ public class CdpTracker extends Tracker {
 
     public void trackCustomEvent(String eventName, Map<String, String> attributes, String itemKey, String itemId) {
         if (!isInited) return;
-        if (TextUtils.isEmpty(itemKey) || TextUtils.isEmpty(itemId)) {
-            Logger.e(TAG, "trackCustomEvent: itemKey or itemId is NULL");
+        if (TextUtils.isEmpty(eventName) || TextUtils.isEmpty(itemKey) || TextUtils.isEmpty(itemId)) {
+            Logger.e(TAG, "trackCustomEvent: eventName, itemKey or itemId is NULL");
             return;
         }
 


### PR DESCRIPTION
## PR 内容

fix: cdp trackCustomEvent 添加缺失的 eventName 字段验证

## 测试步骤

当 eventName 为空时，不产生事件

## 影响范围

Public API trackCustomEvent() 调用

## 是否属于重要变动？

- [ ] 是
- [x] 否


## 其他信息

无
