### PR TITLE
添加模块下的混淆规则

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         ]
 
         releaseConfiguration = [
-                releaseVersion    : "3.3.5-SNAPSHOT",
+                releaseVersion    : "3.3.5",
                 releaseVersionCode: 30305,
         ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,11 +70,11 @@ buildscript {
                         'auto_service'            : 'com.google.auto.service:auto-service:1.0-rc7',
                         'auto_service_annotations': 'com.google.auto.service:auto-service-annotations:1.0-rc7',
 
-                        'protobuf_gradle_plugin'  : 'com.google.protobuf:protobuf-gradle-plugin:0.8.17',
-                        'protobuf_java'           : 'com.google.protobuf:protobuf-java:3.19.1',
-                        'protobuf_javalite'       : 'com.google.protobuf:protobuf-javalite:3.19.1',
-                        'protobufc'               : 'com.google.protobuf:protoc:3.9.1',
-                        'protobuf_java_util'      : 'com.google.protobuf:protobuf-java-util:3.19.1',
+                        'protobuf_gradle_plugin'  : 'com.google.protobuf:protobuf-gradle-plugin:0.8.18',
+                        'protobuf_java'           : 'com.google.protobuf:protobuf-java:3.19.4',
+                        'protobuf_javalite'       : 'com.google.protobuf:protobuf-javalite:3.19.4',
+                        'protobufc'               : 'com.google.protobuf:protoc:3.19.4',
+                        'protobuf_java_util'      : 'com.google.protobuf:protobuf-java-util:3.19.4',
                 ],
 
                 'squareup' : [

--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ buildscript {
         ]
 
         releaseConfiguration = [
-                releaseVersion    : "3.3.4",
-                releaseVersionCode: 30304,
+                releaseVersion    : "3.3.5-SNAPSHOT",
+                releaseVersionCode: 30305,
         ]
 
         versions = [
@@ -31,7 +31,7 @@ buildscript {
                         'navigation_ui'      : 'android.arch.navigation:navigation-ui:1.0.0',
                         'livedata'           : 'android.arch.lifecycle:livedata:1.1.1',
                         'viewmodel'          : 'android.arch.lifecycle:viewmodel:1.1.1',
-                        'volley'             : 'com.android.volley:volley:1.2.0',
+                        'volley'             : 'com.android.volley:volley:1.2.1',
                 ],
 
                 'androidx' : [

--- a/growingio-autotracker-core/consumer-proguard-rules.pro
+++ b/growingio-autotracker-core/consumer-proguard-rules.pro
@@ -1,7 +1,7 @@
--keep class com.growingio.** {
-    *;
-}
--dontwarn com.growingio.**
+#-keep class com.growingio.** {
+#    *;
+#}
+#-dontwarn com.growingio.**
 -keepnames class * extends android.view.View
 -keepnames class * extends android.app.Fragment
 -keepnames class * extends android.support.v4.app.Fragment

--- a/growingio-autotracker-core/consumer-proguard-rules.pro
+++ b/growingio-autotracker-core/consumer-proguard-rules.pro
@@ -1,7 +1,3 @@
-#-keep class com.growingio.** {
-#    *;
-#}
-#-dontwarn com.growingio.**
 -keepnames class * extends android.view.View
 -keepnames class * extends android.app.Fragment
 -keepnames class * extends android.support.v4.app.Fragment

--- a/growingio-autotracker-gradle-plugin/src/main/java/com/growingio/sdk/plugin/autotrack/compile/ClassRewriter.java
+++ b/growingio-autotracker-gradle-plugin/src/main/java/com/growingio/sdk/plugin/autotrack/compile/ClassRewriter.java
@@ -40,7 +40,7 @@ public class ClassRewriter {
     private final String[] mUserExcludePackages;
     private final boolean mExcludeOfficial;
     private static final String[] EXCLUDED_PACKAGES = new String[]{
-            "com/growingio/android/sdk/",
+            "com/growingio/android/",
             "com/growingio/giokit/",
             "com/alibaba/mobileim/extra/xblink/webview",
             "com/alibaba/sdk/android/feedback/xblink",

--- a/growingio-data/database/src/main/AndroidManifest.xml
+++ b/growingio-data/database/src/main/AndroidManifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.growingio.database" >
+    package="com.growingio.android.database" >
 
     <application>
         <provider
-            android:name="com.growingio.database.EventDataContentProvider"
+            android:name="com.growingio.android.database.EventDataContentProvider"
             android:authorities="${applicationId}.EventDataContentProvider"
             android:grantUriPermissions="true"
             android:exported="false" />

--- a/growingio-data/database/src/main/java/com/growingio/android/database/DatabaseDataFetcher.java
+++ b/growingio-data/database/src/main/java/com/growingio/android/database/DatabaseDataFetcher.java
@@ -14,7 +14,7 @@
  *   limitations under the License.
  */
 
-package com.growingio.database;
+package com.growingio.android.database;
 
 import android.text.TextUtils;
 

--- a/growingio-data/database/src/main/java/com/growingio/android/database/DatabaseDataLoader.java
+++ b/growingio-data/database/src/main/java/com/growingio/android/database/DatabaseDataLoader.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.growingio.database;
+package com.growingio.android.database;
 
 import android.content.Context;
 

--- a/growingio-data/database/src/main/java/com/growingio/android/database/DatabaseLibraryModule.java
+++ b/growingio-data/database/src/main/java/com/growingio/android/database/DatabaseLibraryModule.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.growingio.database;
+package com.growingio.android.database;
 
 import android.content.Context;
 

--- a/growingio-data/database/src/main/java/com/growingio/android/database/DeprecatedEventSQLite.java
+++ b/growingio-data/database/src/main/java/com/growingio/android/database/DeprecatedEventSQLite.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.growingio.database;
+package com.growingio.android.database;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
@@ -33,9 +33,9 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.growingio.database.EventDataTable.COLUMN_DATA;
-import static com.growingio.database.EventDataTable.COLUMN_ID;
-import static com.growingio.database.EventDataTable.TABLE_EVENTS;
+import static com.growingio.android.database.EventDataTable.COLUMN_DATA;
+import static com.growingio.android.database.EventDataTable.COLUMN_ID;
+import static com.growingio.android.database.EventDataTable.TABLE_EVENTS;
 
 
 /**

--- a/growingio-data/database/src/main/java/com/growingio/android/database/EventDataContentProvider.java
+++ b/growingio-data/database/src/main/java/com/growingio/android/database/EventDataContentProvider.java
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-package com.growingio.database;
+package com.growingio.android.database;
+
+import static com.growingio.android.database.EventDataTable.TABLE_EVENTS;
 
 import android.content.ContentProvider;
 import android.content.ContentUris;
@@ -25,8 +27,6 @@ import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
 import android.util.Log;
-
-import static com.growingio.database.EventDataTable.TABLE_EVENTS;
 
 public class EventDataContentProvider extends ContentProvider {
 

--- a/growingio-data/database/src/main/java/com/growingio/android/database/EventDataManager.java
+++ b/growingio-data/database/src/main/java/com/growingio/android/database/EventDataManager.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.growingio.database;
+package com.growingio.android.database;
 
 import android.annotation.SuppressLint;
 import android.content.ContentProviderClient;
@@ -37,12 +37,12 @@ import com.growingio.android.sdk.track.modelloader.ModelLoader;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.growingio.database.EventDataTable.COLUMN_DATA;
-import static com.growingio.database.EventDataTable.COLUMN_EVENT_TYPE;
-import static com.growingio.database.EventDataTable.COLUMN_ID;
-import static com.growingio.database.EventDataTable.COLUMN_POLICY;
-import static com.growingio.database.EventDataTable.TABLE_EVENTS;
-import static com.growingio.database.EventDataTable.getContentUri;
+import static com.growingio.android.database.EventDataTable.COLUMN_DATA;
+import static com.growingio.android.database.EventDataTable.COLUMN_EVENT_TYPE;
+import static com.growingio.android.database.EventDataTable.COLUMN_ID;
+import static com.growingio.android.database.EventDataTable.COLUMN_POLICY;
+import static com.growingio.android.database.EventDataTable.TABLE_EVENTS;
+import static com.growingio.android.database.EventDataTable.getContentUri;
 
 public class EventDataManager {
     private static final String TAG = "EventDataManager";

--- a/growingio-data/database/src/main/java/com/growingio/android/database/EventDataSQLiteOpenHelper.java
+++ b/growingio-data/database/src/main/java/com/growingio/android/database/EventDataSQLiteOpenHelper.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.growingio.database;
+package com.growingio.android.database;
 
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;

--- a/growingio-data/database/src/main/java/com/growingio/android/database/EventDataTable.java
+++ b/growingio-data/database/src/main/java/com/growingio/android/database/EventDataTable.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.growingio.database;
+package com.growingio.android.database;
 
 import android.content.ContentValues;
 import android.net.Uri;

--- a/growingio-data/database/src/test/java/com/growingio/android/database/DbTest.java
+++ b/growingio-data/database/src/test/java/com/growingio/android/database/DbTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.growingio.database;
+package com.growingio.android.database;
 
 import android.app.Application;
 import android.content.pm.ProviderInfo;

--- a/growingio-data/protobuf/build.gradle
+++ b/growingio-data/protobuf/build.gradle
@@ -16,6 +16,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'consumer-rules.pro'
         }
     }
 

--- a/growingio-data/protobuf/consumer-rules.pro
+++ b/growingio-data/protobuf/consumer-rules.pro
@@ -1,0 +1,2 @@
+-keep class * extends com.google.protobuf.GeneratedMessageLite { *; }
+-keep public class * extends com.google.protobuf.** { *; }

--- a/growingio-hybrid/build.gradle
+++ b/growingio-hybrid/build.gradle
@@ -16,6 +16,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'consumer-rules.pro'
         }
     }
 

--- a/growingio-tools/oaid/build.gradle
+++ b/growingio-tools/oaid/build.gradle
@@ -15,6 +15,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'consumer-proguard-rules.pro'
         }
     }
 

--- a/growingio-tools/oaid/consumer-proguard-rules.pro
+++ b/growingio-tools/oaid/consumer-proguard-rules.pro
@@ -1,0 +1,3 @@
+# oaid sdk
+-keep class com.bun.miitmdid.** { *; }
+-keep interface com.bun.supplier.** { *; }

--- a/growingio-tracker-core/consumer-proguard-rules.pro
+++ b/growingio-tracker-core/consumer-proguard-rules.pro
@@ -1,8 +1,3 @@
-#-keep class com.growingio.** {
-#    *;
-#}
-#-dontwarn com.growingio.**
-
 -keepnames class * extends android.view.View
 -keepnames class * extends android.app.Fragment
 -keepnames class * extends android.support.v4.app.Fragment
@@ -22,3 +17,4 @@
 
 -keep class * extends com.growingio.android.sdk.LibraryGioModule
 -keep class * extends com.growingio.android.sdk.GeneratedGioModule
+-keep class com.growingio.android.sdk.Generated** {*;}

--- a/growingio-tracker-core/consumer-proguard-rules.pro
+++ b/growingio-tracker-core/consumer-proguard-rules.pro
@@ -1,7 +1,8 @@
--keep class com.growingio.** {
-    *;
-}
--dontwarn com.growingio.**
+#-keep class com.growingio.** {
+#    *;
+#}
+#-dontwarn com.growingio.**
+
 -keepnames class * extends android.view.View
 -keepnames class * extends android.app.Fragment
 -keepnames class * extends android.support.v4.app.Fragment
@@ -18,3 +19,9 @@
 -keep class androidx.viewpager.widget.ViewPager$**{
     *;
 }
+
+-keep class * extends com.growingio.android.sdk.LibraryGioModule
+-keep class * extends com.growingio.android.sdk.GeneratedGioModule
+
+# Uncomment for DexGuard only
+#-keepresourcexmlelements manifest/application/meta-data@value=GlideModule

--- a/growingio-tracker-core/consumer-proguard-rules.pro
+++ b/growingio-tracker-core/consumer-proguard-rules.pro
@@ -22,6 +22,3 @@
 
 -keep class * extends com.growingio.android.sdk.LibraryGioModule
 -keep class * extends com.growingio.android.sdk.GeneratedGioModule
-
-# Uncomment for DexGuard only
-#-keepresourcexmlelements manifest/application/meta-data@value=GlideModule

--- a/growingio-tracker-core/proguard-rules.pro
+++ b/growingio-tracker-core/proguard-rules.pro
@@ -19,10 +19,3 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
-
-
--keep class * extends com.growingio.android.sdk.LibraryGioModule
--keep class * extends com.growingio.android.sdk.GeneratedGioModule
-
-# Uncomment for DexGuard only
-#-keepresourcexmlelements manifest/application/meta-data@value=GlideModule

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/middleware/EventSenderTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/middleware/EventSenderTest.java
@@ -28,8 +28,8 @@ import com.growingio.android.sdk.TrackerContext;
 import com.growingio.android.sdk.track.events.CustomEvent;
 import com.growingio.android.sdk.track.middleware.format.EventByteArray;
 import com.growingio.android.sdk.track.middleware.format.EventFormatData;
-import com.growingio.database.DatabaseDataLoader;
-import com.growingio.database.EventDataContentProvider;
+import com.growingio.android.database.DatabaseDataLoader;
+import com.growingio.android.database.EventDataContentProvider;
 import com.growingio.protobuf.EventV3Protocol;
 import com.growingio.protobuf.ProtobufDataLoader;
 


### PR DESCRIPTION
## PR 内容

1. 对 database 模块重新命名-补充了遗失的android；
2. 检查每个模块的混淆规则；


## 测试步骤

以release环境情况下测试sdk是否能够正常运行
```
release {
    zipAlignEnabled true
    minifyEnabled true
    shrinkResources true
    proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
    signingConfig signingConfigs.release
}
```


## 影响范围

需要在混淆情况下全部走一遍测试


## 是否属于重要变动？

- [x] 是
- [ ] 否


## 其他信息


