### PR TITLE
解决父类重叠的情况下，部分注入点失效的问题

### DIFF
--- a/growingio-autotracker-gradle-plugin/src/main/java/com/growingio/sdk/plugin/autotrack/compile/visitor/InjectAroundClassVisitor.java
+++ b/growingio-autotracker-gradle-plugin/src/main/java/com/growingio/sdk/plugin/autotrack/compile/visitor/InjectAroundClassVisitor.java
@@ -30,6 +30,8 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.commons.Method;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class InjectAroundClassVisitor extends ClassVisitor {
@@ -119,21 +121,27 @@ public class InjectAroundClassVisitor extends ClassVisitor {
     }
 
     private TargetMethod findTargetMethod(String className, String methodName, String methodDesc) {
-        TargetClass targetClass = findTargetClass(className);
-        if (targetClass != null) {
-            return targetClass.getTargetMethod(methodName, methodDesc);
+        List<TargetClass> targetClass = findTargetClass(className);
+        for (TargetClass tClass : targetClass) {
+            if (tClass != null) {
+                TargetMethod method = tClass.getTargetMethod(methodName, methodDesc);
+                if (method != null) {
+                    return method;
+                }
+            }
         }
         return null;
     }
 
-    private TargetClass findTargetClass(String className) {
+    private List<TargetClass> findTargetClass(String className) {
+        List<TargetClass> list = new ArrayList<>();
         Map<String, TargetClass> aroundHookClasses = HookClassesConfig.getAroundHookClasses();
         for (String clazz : aroundHookClasses.keySet()) {
             if (isAssignable(className, clazz)) {
-                return aroundHookClasses.get(clazz);
+                list.add(aroundHookClasses.get(clazz));
             }
         }
-        return null;
+        return list;
     }
 
     private boolean isAssignable(String subClassName, String superClassName) {


### PR DESCRIPTION
## PR 内容

发现有的时候添加的插桩配置部分没插桩成功，例如

```java
public class DialogInjector {

    @After(clazz = Dialog.class,method = "show")
    public static void dialogShow(Dialog alertDialog) {
        Log.d("ASMInjector", "\t\n" + Thread.currentThread().getStackTrace()[3].toString() + "\n" + Thread.currentThread().getStackTrace()[2].toString());
    }
    @After(clazz = DialogInterface.class, method = "dismiss")
    public static void dialogDismiss(DialogInterface alertDialog) {
        Log.d("ASMInjector", "\t\n" + Thread.currentThread().getStackTrace()[3].toString() + "\n" + Thread.currentThread().getStackTrace()[2].toString());
    }
}
```
Dialog.show() 这个插桩配置失效。

分析了下原因，发现是因为[InjectAroundClassVisitor](https://github.com/growingio/growingio-sdk-android-autotracker/blob/fd935718bd3b76ae96bf4b6ff9d46190b6e0120c/growingio-autotracker-gradle-plugin/src/main/java/com/growingio/sdk/plugin/autotrack/compile/visitor/InjectAroundClassVisitor.java#L129) 这里查找逻辑只以第一个找到的class为准，由于：Dialog  实现了 DialogInterface 接口，findTargetClass 查找逻辑先找到了 DialogInterface（会因为插桩配置的代码顺序有一定的偶然性），然后忽略了 Dialog 的注入配置，使得 Dialog.show() 这个插桩配置失效了。

```java
public class Dialog implements DialogInterface, Window.Callback,
        KeyEvent.Callback, OnCreateContextMenuListener, Window.OnWindowDismissedCallback {
```

同理，假设我加入了 KeyEvent.Callback 的方法注入配置，也会让Dialog的配置失效。

修复方式：

找到所有与目标类 “instanceof” 的 TargetClass，然后遍历寻找对应的 TargetMethod。


## 测试步骤

按照以下配置测试：

```java
public class DialogInjector {
    @After(clazz = Dialog.class,method = "show")
    public static void dialogShow(Dialog alertDialog) {
        Log.d("ASMInjector", "\t\n" + Thread.currentThread().getStackTrace()[3].toString() + "\n" + Thread.currentThread().getStackTrace()[2].toString());
    }
    @After(clazz = DialogInterface.class, method = "dismiss")
    public static void dialogDismiss(DialogInterface alertDialog) {
        Log.d("ASMInjector", "\t\n" + Thread.currentThread().getStackTrace()[3].toString() + "\n" + Thread.currentThread().getStackTrace()[2].toString());
    }
}
```

修复完成后，得到以下结果：

插桩前：
```java
            Dialog dialog = new Dialog(null);
            dialog.show();
            dialog.dismiss();
```
插桩后：
```java
            Dialog dialog = new Dialog((Context)null);
            dialog.show();
            DialogInjector.dialogShow(dialog);
            dialog.dismiss();
            DialogInjector.dialogDismiss(dialog);
```


## 影响范围

可能会扩大插桩范围。需要评估一下。


## 是否属于重要变动？

- [ ] 是
- [x] 否


## 其他信息

可能有没考虑到的地方，请谨慎😂

