### PR TITLE
Fix/session

### DIFF
--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/PersistentDataProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/PersistentDataProvider.java
@@ -191,7 +191,7 @@ public class PersistentDataProvider {
 
             if (isFirstProcess) {
                 setActivityCount(0);
-                setLatestPauseTime(System.currentTimeMillis());
+                setLatestPauseTime(0L);
                 setLatestNonNullUserId(getLoginUserId());
 
                 SessionProvider.get().refreshSessionId();


### PR DESCRIPTION
## PR 内容
sessioninterval 设置过短，在首次app启动时，如果启动耗时过长，会导致进入首屏时刷新session，并重发vst


## 测试步骤
sessionInterval设置为1，在Application初始化完成后，使用Thread.sleep模拟耗时操作，进入activity时会重发vst，并刷新session


## 影响范围
sessionInterval设置过短时，可能带来准确性问题
仅涉及不延迟初始化，并且sessionInterval修改为过短时间的场景


## 是否属于重要变动？

- [ ] 是
- [x] 否


## 其他信息


