### PR TITLE
fix: findPage getTitle() 增加非空判断

### DIFF
--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/inject/ViewClickProvider.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/inject/ViewClickProvider.java
@@ -46,7 +46,6 @@ class ViewClickProvider {
 
         // 为了防止click事件重复发送
         if (ClassUtil.isDuplicateClick(view)) {
-            view.hasOnClickListeners();
             Logger.e(TAG, "Duplicate Click");
             return;
         }

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/PageProvider.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/PageProvider.java
@@ -486,15 +486,16 @@ public class PageProvider implements IActivityLifecycle {
                 return ALL_PAGE_TREE.get(activity);
             } else {
                 //一般不会进入，如果出现则新生成page返回
+                //如穿山甲广告：会自己生成一个ActivityWrapper做代理并自己控制生命周期导致sdk的page无法命中，具体类为：PluginFragmentActivityWrapper
                 ActivityPage newPage = new ActivityPage(activity);
                 if (!TextUtils.isEmpty(activity.getTitle())) {
                     newPage.setTitle(activity.getTitle().toString());
+                } else {
+                    newPage.setTitle("WrapperActivity");
                 }
                 return newPage;
             }
         }
-
-        // TODO: 2020/6/10 这种情况需要观察
-        throw new NullPointerException("Page is NULL");
+        return null;
     }
 }

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/PageProvider.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/PageProvider.java
@@ -487,7 +487,9 @@ public class PageProvider implements IActivityLifecycle {
             } else {
                 //一般不会进入，如果出现则新生成page返回
                 ActivityPage newPage = new ActivityPage(activity);
-                newPage.setTitle(activity.getTitle().toString());
+                if (!TextUtils.isEmpty(activity.getTitle())) {
+                    newPage.setTitle(activity.getTitle().toString());
+                }
                 return newPage;
             }
         }


### PR DESCRIPTION
## PR 内容

- fix: findPage getTitle() 增加非空判断
- 原因：穿山甲广告会自己生成一个ActivityWrapper做代理并自己控制生命周期导致sdk的page无法命中，具体类为：PluginFragmentActivityWrapper，且wrapper类并未重载源Activity的getTitle()方法，导致title为空。

## 测试步骤

- CI 通过

## 影响范围

- `activity.getTitle()` 为 null 时，不应该报错

## 是否属于重要变动？

- [ ] 是
- [x] 否


## 其他信息

无
