### PR TITLE
Feat/event filter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,9 @@
 buildscript {
     ext {
         buildConfiguration = [
-                compileVersion     : 30,
+                compileVersion     : 32,
                 minSdkVersion      : 17,
-                targetSdkVersion   : 30,
+                targetSdkVersion   : 32,
                 sourceCompatibility: JavaVersion.VERSION_1_8,
                 targetCompatibility: JavaVersion.VERSION_1_8,
         ]
@@ -106,17 +106,19 @@ buildscript {
                 ],
 
                 'test'     : [
-                        'junit'                         : 'junit:junit:4.13',
-                        'androidx_core'                 : 'androidx.test:core:1.3.0',
-                        'androidx_runner'               : 'androidx.test:runner:1.3.0',
-                        'androidx_rules'                : 'androidx.test:rules:1.3.0',
+                        'junit'                         : 'junit:junit:4.13.2',
+                        'androidx_core'                 : 'androidx.test:core:1.4.0',
+                        'androidx_runner'               : 'androidx.test:runner:1.4.0',
+                        'androidx_rules'                : 'androidx.test:rules:1.4.0',
                         'androidx_truth'                : 'androidx.test.ext:truth:1.3.0',
-                        'androidx_fragment'             : 'androidx.fragment:fragment-testing:1.3.0',
-                        'androidx_junit'                : 'androidx.test.ext:junit:1.1.2',
-                        'robolectric'                   : "org.robolectric:robolectric:4.5.1",
-                        'espresso_core'                 : 'androidx.test.espresso:espresso-core:3.3.0',
-                        'espresso_web'                  : 'androidx.test.espresso:espresso-web:3.3.0',
-                        'orchestrator'                  : 'androidx.test:orchestrator:1.3.0',
+                        'androidx_fragment'             : 'androidx.fragment:fragment-testing:1.4.0',
+                        'androidx_junit'                : 'androidx.test.ext:junit:1.1.3',
+                        'espresso_core'                 : 'androidx.test.espresso:espresso-core:3.4.0',
+                        'espresso_web'                  : 'androidx.test.espresso:espresso-web:3.4.0',
+                        'orchestrator'                  : 'androidx.test:orchestrator:1.4.1',
+
+                        'robolectric'                   : "org.robolectric:robolectric:4.8.1",
+
                         'mockito_core'                  : 'org.mockito:mockito-core:2.24.0',
                         'powermock_core'                : 'org.powermock:powermock-core:2.0.9',
                         'powermock_api_mockito2'        : 'org.powermock:powermock-api-mockito2:2.0.9',

--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,10 @@ buildscript {
                 bomVersion        : "1.0.0.0",
                 bomVersionCode    : 10000,
 
-                releaseVersion    : "3.4.1",
-                releaseVersionCode: 30401,
+                releaseVersion    : "3.4.2-SNAPSHOT",
+                releaseVersionCode: 30402,
 
-                pluginVersion     : "3.4.0",
+                pluginVersion     : "3.4.1",
         ]
 
         versions = [

--- a/demos/demo-autotrack/src/main/AndroidManifest.xml
+++ b/demos/demo-autotrack/src/main/AndroidManifest.xml
@@ -24,36 +24,64 @@
     <application>
         <activity
             android:name=".activity.ActionMenuViewActivity"
+            android:exported="false"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
         <activity
             android:name=".activity.ToolBarActivity"
+            android:exported="false"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
         <activity android:name=".activity.ViewImpressionActivity" />
         <activity
             android:name=".activity.ui.login.LoginActivity"
+            android:exported="false"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
-        <activity android:name=".activity.ExpandableListSubActivity" />
-        <activity android:name=".activity.ExpandableListViewActivity" />
-        <activity android:name=".activity.ClickTestActivity" />
-        <activity android:name=".activity.RecyclerViewImpActivity" />
+        <activity
+            android:name=".activity.ExpandableListSubActivity"
+            android:exported="false" />
+        <activity
+            android:name=".activity.ExpandableListViewActivity"
+            android:exported="false" />
+        <activity
+            android:name=".activity.ClickTestActivity"
+            android:exported="false" />
+        <activity
+            android:name=".activity.RecyclerViewImpActivity"
+            android:exported="false" />
         <activity
             android:name=".activity.AddPeopleDialogActivity"
+            android:exported="false"
             android:theme="@style/dialog_style" />
-        <activity android:name=".activity.LambdaActivity" />
-        <activity android:name=".activity.DialogTestActivity" />
-        <activity android:name=".activity.WebViewActivity" />
-        <activity android:name=".activity.X5WebViewActivity" />
+        <activity
+            android:name=".activity.LambdaActivity"
+            android:exported="false" />
+        <activity
+            android:name=".activity.DialogTestActivity"
+            android:exported="false" />
+        <activity
+            android:name=".activity.WebViewActivity"
+            android:exported="false" />
+        <activity
+            android:name=".activity.X5WebViewActivity"
+            android:exported="false" />
         <activity
             android:name=".activity.TabFragmentActivity"
+            android:exported="false"
             android:label="@string/title_activity_tab_fragment"
             android:theme="@style/Theme.App.NoActionBar" />
         <activity
             android:name=".activity.NavFragmentActivity"
+            android:exported="false"
             android:label="@string/title_activity_view_pager"
             android:theme="@style/Theme.App" />
-        <activity android:name=".activity.HideFragmentActivity" />
-        <activity android:name=".activity.NestedFragmentActivity" />
-        <activity android:name=".AutotrackEntryActivity">
+        <activity
+            android:name=".activity.HideFragmentActivity"
+            android:exported="false" />
+        <activity
+            android:name=".activity.NestedFragmentActivity"
+            android:exported="false" />
+        <activity
+            android:name=".AutotrackEntryActivity"
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.gio.test.three.Entry" />
             </intent-filter>

--- a/demos/demo/src/main/AndroidManifest.xml
+++ b/demos/demo/src/main/AndroidManifest.xml
@@ -30,8 +30,7 @@
         android:label="demos"
         android:usesCleartextTraffic="true"
         tools:targetApi="m">
-        <activity android:name="com.growingio.autotest.MainActivity"></activity>
-        <activity android:name=".MainActivity" />
+        <activity android:name="com.growingio.autotest.MainActivity" android:exported="true" />
 
         <service
             android:name=".three.OtherProcessService"
@@ -39,7 +38,7 @@
             android:exported="true"
             android:process=":OtherProcess" />
 
-        <activity android:name=".three.MainActivity">
+        <activity android:name=".three.MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -120,7 +119,8 @@
                     android:scheme="https" />
             </intent-filter>
         </activity>
-        <activity android:name=".three.core.TrackActivity">
+        <activity android:name=".three.core.TrackActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="com.gio.test.three.Entry" />
             </intent-filter>

--- a/growingio-autotracker-core/build.gradle
+++ b/growingio-autotracker-core/build.gradle
@@ -10,9 +10,9 @@ android {
     }
 
     buildTypes {
-        debug {
-            testCoverageEnabled = true
-        }
+//        debug {
+//            testCoverageEnabled = true
+//        }
 
         release {
             minifyEnabled false
@@ -29,6 +29,7 @@ android {
     testOptions {
         unitTests.all {
             jacoco {
+                jvmArgs '-noverify'
                 includeNoLocationClasses = true
                 excludes = ['jdk.internal.*']
             }

--- a/growingio-autotracker-core/src/test/java/com/growingio/android/sdk/autotrack/AutotrackTest.java
+++ b/growingio-autotracker-core/src/test/java/com/growingio/android/sdk/autotrack/AutotrackTest.java
@@ -49,7 +49,7 @@ public class AutotrackTest {
         autotracker = new Autotracker(application);
         Map<Class<? extends Configurable>, Configurable> modules = new HashMap<>();
         modules.put(AutotrackConfig.class, new AutotrackConfig().setImpressionScale(0.5f));
-        ConfigurationProvider.initWithConfig(new CoreConfiguration("test", "test"), modules);
+        ConfigurationProvider.initWithConfig(new CoreConfiguration("AutotrackTest", "growingio://autotrack"), modules);
     }
 
     @Test

--- a/growingio-autotracker-core/src/test/java/com/growingio/android/sdk/autotrack/impression/ImpressionTest.java
+++ b/growingio-autotracker-core/src/test/java/com/growingio/android/sdk/autotrack/impression/ImpressionTest.java
@@ -51,7 +51,7 @@ public class ImpressionTest {
         TrackerContext.init(application);
         Map<Class<? extends Configurable>, Configurable> map = new HashMap<>();
         map.put(AutotrackConfig.class, new AutotrackConfig());
-        ConfigurationProvider.initWithConfig(new CoreConfiguration("test", "test"), map);
+        ConfigurationProvider.initWithConfig(new CoreConfiguration("ImpressionTest", "growingio://impression"), map);
     }
 
     @Test

--- a/growingio-data/database/src/main/java/com/growingio/android/database/EventDataContentProvider.java
+++ b/growingio-data/database/src/main/java/com/growingio/android/database/EventDataContentProvider.java
@@ -111,4 +111,10 @@ public class EventDataContentProvider extends ContentProvider {
         }
         throw new IllegalArgumentException("UnKnow Uri:" + uri.toString());
     }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        dbHelper.close();
+    }
 }

--- a/growingio-hybrid/src/test/java/com/growingio/android/hybrid/HybridTest.java
+++ b/growingio-hybrid/src/test/java/com/growingio/android/hybrid/HybridTest.java
@@ -65,7 +65,7 @@ public class HybridTest {
     public void setup() {
         TrackerContext.init(application);
         TrackerContext.initSuccess();
-        ConfigurationProvider.initWithConfig(new CoreConfiguration("test", "test"), new HashMap<>());
+        ConfigurationProvider.initWithConfig(new CoreConfiguration("HybridTest", "growingio://Hybrid"), new HashMap<>());
     }
 
 

--- a/growingio-tracker-core/build.gradle
+++ b/growingio-tracker-core/build.gradle
@@ -18,9 +18,9 @@ android {
     }
 
     buildTypes {
-        debug {
-            testCoverageEnabled = true
-        }
+//        debug {
+//            testCoverageEnabled = true
+//        }
 
         release {
             minifyEnabled false
@@ -37,6 +37,7 @@ android {
     testOptions {
         unitTests.all {
             jacoco {
+                jvmArgs '-noverify'
                 includeNoLocationClasses = true
                 excludes = ['jdk.internal.*']
             }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/CoreConfiguration.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/CoreConfiguration.java
@@ -18,6 +18,7 @@ package com.growingio.android.sdk;
 
 import android.text.TextUtils;
 
+import com.growingio.android.sdk.track.events.EventFilterInterceptor;
 import com.growingio.android.sdk.track.events.helper.EventExcludeFilter;
 import com.growingio.android.sdk.track.events.helper.FieldIgnoreFilter;
 import com.growingio.android.sdk.track.utils.ObjectUtils.FieldToString;
@@ -38,10 +39,15 @@ public class CoreConfiguration implements Configurable {
     private boolean mUploadExceptionEnabled = true;
     private boolean mRequireAppProcessesEnabled = true;
     private String mDataCollectionServerHost = "http://api.growingio.com";
+
+
+    private EventFilterInterceptor mEventFilterInterceptor;
     @FieldToString(clazz = EventExcludeFilter.class, method = "getEventFilterLog", parameterTypes = {int.class})
     private int mExcludeEventFlag = EventExcludeFilter.NONE;
     @FieldToString(clazz = FieldIgnoreFilter.class, method = "getFieldFilterLog", parameterTypes = {int.class})
     private int mIgnoreFieldFlag = FieldIgnoreFilter.NONE;
+
+
     private final List<LibraryGioModule> mComponents = new ArrayList<>();
     private boolean mIdMappingEnabled = false;
 
@@ -138,6 +144,16 @@ public class CoreConfiguration implements Configurable {
         return this;
     }
 
+    public EventFilterInterceptor getEventFilterInterceptor() {
+        return mEventFilterInterceptor;
+    }
+
+    public CoreConfiguration setEventFilterInterceptor(EventFilterInterceptor eventFilterInterceptor) {
+        this.mEventFilterInterceptor = eventFilterInterceptor;
+        return this;
+    }
+
+    @Deprecated
     public CoreConfiguration setExcludeEvent(@EventExcludeFilter.EventFilterLimit int filterEventFlag) {
         if (filterEventFlag == EventExcludeFilter.NONE) {
             this.mExcludeEventFlag = EventExcludeFilter.NONE;
@@ -147,10 +163,12 @@ public class CoreConfiguration implements Configurable {
         return this;
     }
 
+    @Deprecated
     public int getExcludeEvent() {
         return mExcludeEventFlag;
     }
 
+    @Deprecated
     public CoreConfiguration setIgnoreField(@FieldIgnoreFilter.FieldFilterType int ignoreFieldFlag) {
         if (ignoreFieldFlag == FieldIgnoreFilter.NONE) {
             this.mIgnoreFieldFlag = FieldIgnoreFilter.NONE;
@@ -160,14 +178,11 @@ public class CoreConfiguration implements Configurable {
         return this;
     }
 
+    @Deprecated
     public int getIgnoreField() {
         return mIgnoreFieldFlag;
     }
 
-    @Deprecated
-    public CoreConfiguration setPreloadComponent(LibraryGioModule component) {
-        return addPreloadComponent(component);
-    }
 
     public CoreConfiguration addPreloadComponent(LibraryGioModule component) {
         if (component == null) {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/TrackMainThread.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/TrackMainThread.java
@@ -23,6 +23,8 @@ import android.os.Message;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
+import androidx.annotation.VisibleForTesting;
+
 import com.growingio.android.sdk.CoreConfiguration;
 import com.growingio.android.sdk.track.events.CustomEvent;
 import com.growingio.android.sdk.track.events.EventFilterInterceptor;
@@ -80,6 +82,24 @@ public final class TrackMainThread extends ListenerContainer<OnTrackMainInitSDKC
         mMainHandler = new H(mMainLooper);
         mMainHandler.sendEmptyMessage(MSG_INIT_SDK);
     }
+
+    @VisibleForTesting
+    TrackMainThread(CoreConfiguration configuration){
+        int uploadInterval = configuration.isDebugEnabled() ? 0 : configuration.getDataUploadInterval();
+        mEventSender = new EventSender(new EventHttpSender(), uploadInterval, configuration.getCellularDataLimit());
+        if (configuration.getEventFilterInterceptor() != null) {
+            eventFilterInterceptor = configuration.getEventFilterInterceptor();
+        } else {
+            eventFilterInterceptor = new DefaultEventFilterInterceptor();
+        }
+
+        HandlerThread handlerThread = new HandlerThread(TAG);
+        handlerThread.start();
+        mMainLooper = handlerThread.getLooper();
+        mMainHandler = new H(mMainLooper);
+        mMainHandler.sendEmptyMessage(MSG_INIT_SDK);
+    }
+
 
     /**
      * this api adapt for adSdk(https://github.com/growingio/growingio-sdk-android-advert)

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/TrackMainThread.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/TrackMainThread.java
@@ -84,7 +84,7 @@ public final class TrackMainThread extends ListenerContainer<OnTrackMainInitSDKC
     }
 
     @VisibleForTesting
-    TrackMainThread(CoreConfiguration configuration){
+    TrackMainThread(CoreConfiguration configuration) {
         int uploadInterval = configuration.isDebugEnabled() ? 0 : configuration.getDataUploadInterval();
         mEventSender = new EventSender(new EventHttpSender(), uploadInterval, configuration.getCellularDataLimit());
         if (configuration.getEventFilterInterceptor() != null) {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/TrackMainThread.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/TrackMainThread.java
@@ -21,11 +21,18 @@ import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.Message;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 
 import com.growingio.android.sdk.CoreConfiguration;
+import com.growingio.android.sdk.track.events.CustomEvent;
+import com.growingio.android.sdk.track.events.EventFilterInterceptor;
+import com.growingio.android.sdk.track.events.PageAttributesEvent;
+import com.growingio.android.sdk.track.events.PageEvent;
+import com.growingio.android.sdk.track.events.PageLevelCustomEvent;
+import com.growingio.android.sdk.track.events.ViewElementEvent;
+import com.growingio.android.sdk.track.events.helper.DefaultEventFilterInterceptor;
 import com.growingio.android.sdk.track.ipc.PersistentDataProvider;
 import com.growingio.android.sdk.track.events.EventBuildInterceptor;
-import com.growingio.android.sdk.track.events.helper.EventExcludeFilter;
 import com.growingio.android.sdk.track.events.base.BaseEvent;
 import com.growingio.android.sdk.track.listener.OnTrackMainInitSDKCallback;
 import com.growingio.android.sdk.track.listener.TrackThread;
@@ -40,6 +47,7 @@ import com.growingio.android.sdk.track.middleware.EventHttpSender;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * GrowingIO主线程
@@ -54,10 +62,17 @@ public final class TrackMainThread extends ListenerContainer<OnTrackMainInitSDKC
 
     private final List<EventBuildInterceptor> mEventBuildInterceptors = new ArrayList<>();
 
+    private final EventFilterInterceptor eventFilterInterceptor;
+
     private TrackMainThread() {
         CoreConfiguration configuration = ConfigurationProvider.core();
         int uploadInterval = configuration.isDebugEnabled() ? 0 : configuration.getDataUploadInterval();
         mEventSender = new EventSender(new EventHttpSender(), uploadInterval, configuration.getCellularDataLimit());
+        if (configuration.getEventFilterInterceptor() != null) {
+            eventFilterInterceptor = configuration.getEventFilterInterceptor();
+        } else {
+            eventFilterInterceptor = new DefaultEventFilterInterceptor();
+        }
 
         HandlerThread handlerThread = new HandlerThread(TAG);
         handlerThread.start();
@@ -93,7 +108,6 @@ public final class TrackMainThread extends ListenerContainer<OnTrackMainInitSDKC
 
     @TrackThread
     void initSDK() {
-        //mEventSender.removeOverdueEvents();
         dispatchActions(null);
     }
 
@@ -106,14 +120,6 @@ public final class TrackMainThread extends ListenerContainer<OnTrackMainInitSDKC
                 }
 
                 if (ConfigurationProvider.core().isDataCollectionEnabled()) {
-                    // 判断当前事件类型是否被过滤
-                    if (EventExcludeFilter.isEventFilter(eventBuilder.getEventType())) {
-                        return;
-                    }
-
-                    if (!PersistentDataProvider.get().isSendVisitAfterRefreshSessionId()) {
-                        SessionProvider.get().generateVisit();
-                    }
                     onGenerateGEvent(eventBuilder);
                 }
             }
@@ -147,12 +153,66 @@ public final class TrackMainThread extends ListenerContainer<OnTrackMainInitSDKC
 
     @TrackThread
     void onGenerateGEvent(BaseEvent.BaseBuilder<?> gEvent) {
-        gEvent.readPropertyInTrackThread();
         dispatchEventWillBuild(gEvent);
+
+        if (!filterEvent(gEvent)) return;
+        gEvent.readPropertyInTrackThread();
+
         BaseEvent event = gEvent.build();
         dispatchEventDidBuild(event);
+
         saveEvent(event);
     }
+
+    @TrackThread
+    boolean filterEvent(BaseEvent.BaseBuilder<?> eventBuilder) {
+        if (eventFilterInterceptor == null) return true;
+        /*String eventGroup = "undefine";
+        if (!eventFilterInterceptor.filterEventGroup(eventGroup)) {
+            return false;
+        }*/
+
+        if (!eventFilterInterceptor.filterEventType(eventBuilder.getEventType())) return false;
+
+        String eventPath = getEventPath(eventBuilder);
+        if (!TextUtils.isEmpty(eventPath) && !eventFilterInterceptor.filterEventPath(eventPath)) {
+            return false;
+        }
+
+        String eventName = getEventName(eventBuilder);
+        if (!TextUtils.isEmpty(eventName) && !eventFilterInterceptor.filterEventName(eventName)) {
+            return false;
+        }
+
+        Map<String, Boolean> filterFields = eventFilterInterceptor.filterEventField(eventBuilder.getEventType(), eventBuilder.getFilterMap());
+        eventBuilder.filterFieldProperty(filterFields);
+
+        return true;
+    }
+
+    String getEventName(BaseEvent.BaseBuilder<?> eventBuilder) {
+        if (eventBuilder instanceof CustomEvent.Builder) {
+            return ((CustomEvent.Builder) eventBuilder).getEventName();
+        }
+        return null;
+    }
+
+    String getEventPath(BaseEvent.BaseBuilder<?> eventBuilder) {
+        if (eventBuilder instanceof PageEvent.Builder) {
+            return ((PageEvent.Builder) eventBuilder).getPath();
+        }
+        if (eventBuilder instanceof ViewElementEvent.Builder) {
+            return ((ViewElementEvent.Builder) eventBuilder).getPath();
+        }
+        if (eventBuilder instanceof PageLevelCustomEvent.Builder) {
+            return ((PageLevelCustomEvent.Builder) eventBuilder).getPath();
+        }
+        if (eventBuilder instanceof PageAttributesEvent.Builder) {
+            return ((PageAttributesEvent.Builder) eventBuilder).getPath();
+        }
+        return null;
+    }
+
 
     public void removeEventBuildInterceptor(EventBuildInterceptor interceptor) {
         synchronized (mEventBuildInterceptors) {
@@ -220,6 +280,10 @@ public final class TrackMainThread extends ListenerContainer<OnTrackMainInitSDKC
     private void saveEvent(GEvent event) {
         if (event instanceof BaseEvent) {
             Logger.printJson(TAG, "save: event, type is " + event.getEventType(), ((BaseEvent) event).toJSONObject().toString());
+        }
+        if (!PersistentDataProvider.get().isSendVisitAfterRefreshSessionId()) {
+            // we should resend visitEvent when sessionId refreshed
+            SessionProvider.get().generateVisit();
         }
         mEventSender.sendEvent(event);
     }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/CustomEvent.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/CustomEvent.java
@@ -67,6 +67,10 @@ public class CustomEvent extends BaseAttributesEvent {
             return this;
         }
 
+        public String getEventName() {
+            return mEventName;
+        }
+
         @Override
         public Builder setAttributes(Map<String, String> attributes) {
             super.setAttributes(attributes);

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/EventFilterInterceptor.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/EventFilterInterceptor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020 Beijing Yishu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.growingio.android.sdk.track.events;
+
+import java.util.Map;
+
+public interface EventFilterInterceptor {
+
+    /**
+     * filter events based on eventType
+     *
+     * @param eventType event's type
+     * @return true:pass false:block
+     */
+    boolean filterEventType(String eventType);
+
+    /**
+     * filter custom events based on eventName
+     *
+     * @param eventName custom event's name
+     * @return true:pass false:block
+     */
+    boolean filterEventName(String eventName);
+
+    /**
+     * filter events based on path
+     *
+     * @param path event's path
+     * @return true:pass false:block
+     */
+    boolean filterEventPath(String path);
+
+    /**
+     * filter event's field
+     *
+     * @param type      event's type
+     * @param fieldArea event's field map
+     * @return map. if the value is true,the field will pass,and if the value is false, sdk will make thd field blank.
+     */
+    Map<String, Boolean> filterEventField(String type, Map<String, Boolean> fieldArea);
+
+    /**
+     * <p>
+     * future's feature. it's useless now.
+     * </p>
+     * filter events based on group
+     *
+     * @param group event's group
+     * @return true:pass false:block
+     */
+    boolean filterEventGroup(String group);
+}

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/PageAttributesEvent.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/PageAttributesEvent.java
@@ -67,6 +67,10 @@ public class PageAttributesEvent extends BaseAttributesEvent {
             return this;
         }
 
+        public String getPath() {
+            return mPath;
+        }
+
         public Builder setPageShowTimestamp(long pageShowTimestamp) {
             mPageShowTimestamp = pageShowTimestamp;
             return this;

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/PageEvent.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/PageEvent.java
@@ -109,6 +109,10 @@ public class PageEvent extends BaseEvent {
             return this;
         }
 
+        public String getPath() {
+            return mPath;
+        }
+
         @Override
         public String getEventType() {
             return AutotrackEventType.PAGE;

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/PageLevelCustomEvent.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/PageLevelCustomEvent.java
@@ -81,6 +81,10 @@ public class PageLevelCustomEvent extends CustomEvent {
             return this;
         }
 
+        public String getPath() {
+            return mPath;
+        }
+
         @Override
         public PageLevelCustomEvent build() {
             return new PageLevelCustomEvent(this);

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/ViewElementEvent.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/ViewElementEvent.java
@@ -123,6 +123,10 @@ public class ViewElementEvent extends BaseEvent {
             return this;
         }
 
+        public String getPath() {
+            return mPath;
+        }
+
         @Override
         public ViewElementEvent build() {
             return new ViewElementEvent(this);

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/base/BaseEvent.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/base/BaseEvent.java
@@ -16,7 +16,6 @@
 
 package com.growingio.android.sdk.track.events.base;
 
-
 import android.content.Context;
 import android.support.annotation.CallSuper;
 import android.text.TextUtils;
@@ -25,7 +24,6 @@ import com.growingio.android.sdk.track.SDKConfig;
 import com.growingio.android.sdk.TrackerContext;
 import com.growingio.android.sdk.track.ipc.EventSequenceId;
 import com.growingio.android.sdk.track.ipc.PersistentDataProvider;
-import com.growingio.android.sdk.track.events.helper.FieldIgnoreFilter;
 import com.growingio.android.sdk.track.listener.TrackThread;
 import com.growingio.android.sdk.track.middleware.GEvent;
 import com.growingio.android.sdk.track.providers.ActivityStateProvider;
@@ -232,54 +230,64 @@ public abstract class BaseEvent extends GEvent {
             json = new JSONObject();
         }
         try {
-            json.put("platform", mPlatform);
-            json.put("platformVersion", mPlatformVersion);
-            json.put("deviceId", getDeviceId());
+            json.put(BaseField.PLATFORM, mPlatform);
+            json.put(BaseField.PLATFORM_VERSION, mPlatformVersion);
+            json.put(BaseField.DEVICE_ID, getDeviceId());
             if (!TextUtils.isEmpty(getUserKey())) {
-                json.put("userKey", getUserKey());
+                json.put(BaseField.USER_KEY, getUserKey());
             }
             if (!TextUtils.isEmpty(getUserId())) {
-                json.put("userId", getUserId());
+                json.put(BaseField.USER_ID, getUserId());
             }
-            json.put("sessionId", getSessionId());
-            json.put("eventType", getEventType());
-            json.put("timestamp", getTimestamp());
-            json.put("domain", getDomain());
-            json.put("urlScheme", getUrlScheme());
-            json.put("appState", getAppState());
-            json.put("globalSequenceId", getGlobalSequenceId());
-            json.put("eventSequenceId", getEventSequenceId());
+            json.put(BaseField.SESSION_ID, getSessionId());
+            json.put(BaseField.EVENT_TYPE, getEventType());
+            json.put(BaseField.TIMESTAMP, getTimestamp());
+            json.put(BaseField.GSID, getGlobalSequenceId());
+            json.put(BaseField.ESID, getEventSequenceId());
 
+            json.put(BaseField.DOMAIN, getDomain());
+            json.put(BaseField.URL_SCHEME, getUrlScheme());
+
+            if (!TextUtils.isEmpty(getAppState())) {
+                json.put(BaseField.APP_STATE, getAppState());
+            }
             if (!TextUtils.isEmpty(getNetworkState())) {
-                json.put("networkState", getNetworkState());
+                json.put(BaseField.NETWORK_STATE, getNetworkState());
             }
             if (!TextUtils.isEmpty(getAppChannel())) {
-                json.put("appChannel", getAppChannel());
+                json.put(BaseField.APP_CHANNEl, getAppChannel());
             }
             if (getScreenHeight() > 0) {
-                json.put("screenHeight", getScreenHeight());
+                json.put(BaseField.SCREEN_HEIGHT, getScreenHeight());
             }
             if (getScreenWidth() > 0) {
-                json.put("screenWidth", getScreenWidth());
+                json.put(BaseField.SCREEN_WIDTH, getScreenWidth());
             }
             if (!TextUtils.isEmpty(getDeviceBrand())) {
-                json.put("deviceBrand", getDeviceBrand());
+                json.put(BaseField.DEVICE_BRAND, getDeviceBrand());
             }
             if (!TextUtils.isEmpty(getDeviceModel())) {
-                json.put("deviceModel", getDeviceModel());
+                json.put(BaseField.DEVICE_MODEL, getDeviceModel());
             }
             if (!TextUtils.isEmpty(getDeviceType())) {
-                json.put("deviceType", getDeviceType());
+                json.put(BaseField.DEVICE_TYPE, getDeviceType());
             }
-            json.put("appName", getAppName());
-            json.put("appVersion", getAppVersion());
-            json.put("language", getLanguage());
+            if (!TextUtils.isEmpty(getAppName())) {
+                json.put(BaseField.APP_NAME, getAppName());
+            }
+            if (!TextUtils.isEmpty(getAppVersion())) {
+                json.put(BaseField.APP_VERSION, getAppVersion());
+            }
+            if (!TextUtils.isEmpty(getLanguage())) {
+                json.put(BaseField.LANGUAGE, getLanguage());
+            }
             if (getLatitude() != 0 || getLongitude() != 0) {
-                json.put("latitude", getLatitude());
-                json.put("longitude", getLongitude());
+                json.put(BaseField.LATITUDE, getLatitude());
+                json.put(BaseField.LONGITUDE, getLongitude());
             }
-            json.put("sdkVersion", getSdkVersion());
-
+            if (!TextUtils.isEmpty(getSdkVersion())) {
+                json.put(BaseField.SDK_VERSION, getSdkVersion());
+            }
         } catch (JSONException ignored) {
         }
         return json;
@@ -296,7 +304,7 @@ public abstract class BaseEvent extends GEvent {
         protected long mTimestamp;
         protected String mDomain;
         private final String mUrlScheme;
-        private final String mAppState;
+        private String mAppState;
         private long mGlobalSequenceId;
         private long mEventSequenceId;
         private final Map<String, String> mExtraParams = new HashMap<>();
@@ -324,6 +332,38 @@ public abstract class BaseEvent extends GEvent {
             mUrlScheme = ConfigurationProvider.core().getUrlScheme();
         }
 
+        protected Map<String, Boolean> mFilterField = new HashMap<>();
+
+        @TrackThread
+        public void filterFieldProperty(Map<String, Boolean> filterField) {
+            if (filterField == null) mFilterField.clear();
+            else {
+                mFilterField = filterField;
+            }
+        }
+
+        public Map<String, Boolean> getFilterMap() {
+            //mFilterField.put(BaseField.PLATFORM, true);
+            //mFilterField.put(BaseField.PLATFORM_VERSION, true);
+            //mFilterField.put(BaseField.DOMAIN, true);
+            //mFilterField.put(BaseField.URL_SCHEME, true);
+            mFilterField.put(BaseField.APP_STATE, true);
+            mFilterField.put(BaseField.NETWORK_STATE, true);
+            mFilterField.put(BaseField.SCREEN_HEIGHT, true);
+            mFilterField.put(BaseField.SCREEN_WIDTH, true);
+            mFilterField.put(BaseField.DEVICE_BRAND, true);
+            mFilterField.put(BaseField.DEVICE_MODEL, true);
+            mFilterField.put(BaseField.DEVICE_TYPE, true);
+            mFilterField.put(BaseField.APP_CHANNEl, true);
+            mFilterField.put(BaseField.APP_NAME, true);
+            mFilterField.put(BaseField.APP_VERSION, true);
+            mFilterField.put(BaseField.LANGUAGE, true);
+            mFilterField.put(BaseField.LATITUDE, true);
+            mFilterField.put(BaseField.LONGITUDE, true);
+            mFilterField.put(BaseField.SDK_VERSION, true);
+            return mFilterField;
+        }
+
         @TrackThread
         @CallSuper
         public void readPropertyInTrackThread() {
@@ -336,32 +376,44 @@ public abstract class BaseEvent extends GEvent {
             mGlobalSequenceId = sequenceId.getGlobalId();
             mEventSequenceId = sequenceId.getEventTypeId();
 
+            // filter field area
+            if (!getFieldDefault(BaseField.APP_STATE)) {
+                mAppState = null;
+            }
+
             Context context = TrackerContext.get().getApplicationContext();
-            mNetworkState = FieldIgnoreFilter.isFieldFilter("networkState") ? "" : NetworkUtil.getActiveNetworkState(context).getNetworkName();
+            mNetworkState = getFieldDefault(BaseField.NETWORK_STATE) ? NetworkUtil.getActiveNetworkState(context).getNetworkName() : null;
 
             DeviceInfoProvider deviceInfo = DeviceInfoProvider.get();
-            mScreenHeight = FieldIgnoreFilter.isFieldFilter("screenHeight") ? 0 : deviceInfo.getScreenHeight();
-            mScreenWidth = FieldIgnoreFilter.isFieldFilter("screenWidth") ? 0 : deviceInfo.getScreenWidth();
-            mDeviceBrand = FieldIgnoreFilter.isFieldFilter("deviceBrand") ? "" : deviceInfo.getDeviceBrand();
-            mDeviceModel = FieldIgnoreFilter.isFieldFilter("deviceModel") ? "" : deviceInfo.getDeviceModel();
-            mDeviceType = FieldIgnoreFilter.isFieldFilter("deviceType") ? "" : deviceInfo.getDeviceType();
+            mScreenHeight = getFieldDefault(BaseField.SCREEN_HEIGHT) ? deviceInfo.getScreenHeight() : 0;
+            mScreenWidth = getFieldDefault(BaseField.SCREEN_WIDTH) ? deviceInfo.getScreenWidth() : 0;
+            mDeviceBrand = getFieldDefault(BaseField.DEVICE_BRAND) ? deviceInfo.getDeviceBrand() : null;
+            mDeviceModel = getFieldDefault(BaseField.DEVICE_MODEL) ? deviceInfo.getDeviceModel() : null;
+            mDeviceType = getFieldDefault(BaseField.DEVICE_TYPE) ? deviceInfo.getDeviceType() : null;
 
             AppInfoProvider appInfo = AppInfoProvider.get();
-            mAppChannel = appInfo.getAppChannel();
-            mAppName = appInfo.getAppName();
-            mAppVersion = appInfo.getAppVersion();
+            mAppChannel = getFieldDefault(BaseField.APP_CHANNEl) ? appInfo.getAppChannel() : null;
+            mAppName = getFieldDefault(BaseField.APP_NAME) ? appInfo.getAppName() : null;
+            mAppVersion = getFieldDefault(BaseField.APP_VERSION) ? appInfo.getAppVersion() : null;
 
             SessionProvider session = SessionProvider.get();
-            mLatitude = session.getLatitude();
-            mLongitude = session.getLongitude();
+            mLatitude = getFieldDefault(BaseField.LATITUDE) ? session.getLatitude() : 0;
+            mLongitude = getFieldDefault(BaseField.LONGITUDE) ? session.getLongitude() : 0;
 
-            mSdkVersion = SDKConfig.SDK_VERSION;
-            mLanguage = Locale.getDefault().getLanguage();
+            mSdkVersion = getFieldDefault(BaseField.SDK_VERSION) ? SDKConfig.SDK_VERSION : null;
+            mLanguage = getFieldDefault(BaseField.LANGUAGE) ? Locale.getDefault().getLanguage() : null;
         }
 
         public BaseBuilder<?> addExtraParam(String key, String value) {
             mExtraParams.put(key, value);
             return this;
+        }
+
+        protected Boolean getFieldDefault(String key) {
+            if (mFilterField.containsKey(key)) {
+                return mFilterField.get(key);
+            }
+            return true;
         }
 
         public abstract String getEventType();

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/base/BaseEvent.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/base/BaseEvent.java
@@ -255,7 +255,7 @@ public abstract class BaseEvent extends GEvent {
                 json.put(BaseField.NETWORK_STATE, getNetworkState());
             }
             if (!TextUtils.isEmpty(getAppChannel())) {
-                json.put(BaseField.APP_CHANNEl, getAppChannel());
+                json.put(BaseField.APP_CHANNEL, getAppChannel());
             }
             if (getScreenHeight() > 0) {
                 json.put(BaseField.SCREEN_HEIGHT, getScreenHeight());
@@ -354,7 +354,7 @@ public abstract class BaseEvent extends GEvent {
             mFilterField.put(BaseField.DEVICE_BRAND, true);
             mFilterField.put(BaseField.DEVICE_MODEL, true);
             mFilterField.put(BaseField.DEVICE_TYPE, true);
-            mFilterField.put(BaseField.APP_CHANNEl, true);
+            mFilterField.put(BaseField.APP_CHANNEL, true);
             mFilterField.put(BaseField.APP_NAME, true);
             mFilterField.put(BaseField.APP_VERSION, true);
             mFilterField.put(BaseField.LANGUAGE, true);
@@ -392,7 +392,7 @@ public abstract class BaseEvent extends GEvent {
             mDeviceType = getFieldDefault(BaseField.DEVICE_TYPE) ? deviceInfo.getDeviceType() : null;
 
             AppInfoProvider appInfo = AppInfoProvider.get();
-            mAppChannel = getFieldDefault(BaseField.APP_CHANNEl) ? appInfo.getAppChannel() : null;
+            mAppChannel = getFieldDefault(BaseField.APP_CHANNEL) ? appInfo.getAppChannel() : null;
             mAppName = getFieldDefault(BaseField.APP_NAME) ? appInfo.getAppName() : null;
             mAppVersion = getFieldDefault(BaseField.APP_VERSION) ? appInfo.getAppVersion() : null;
 

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/base/BaseField.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/base/BaseField.java
@@ -21,7 +21,11 @@ package com.growingio.android.sdk.track.events.base;
  *
  * @author cpacm 2022/8/8
  */
-public class BaseField {
+public final class BaseField {
+
+    private BaseField() {
+    }
+
     final static String PLATFORM = "platform";
     final static String PLATFORM_VERSION = "platformVersion";
     final static String USER_KEY = "userKey";
@@ -36,7 +40,7 @@ public class BaseField {
     final static String ESID = "eventSequenceId";
     final static String DEVICE_ID = "deviceId";
     public final static String NETWORK_STATE = "networkState";
-    public final static String APP_CHANNEl = "appChannel";
+    public final static String APP_CHANNEL = "appChannel";
     public final static String SCREEN_HEIGHT = "screenHeight";
     public final static String SCREEN_WIDTH = "screenWidth";
     public final static String DEVICE_BRAND = "deviceBrand";

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/base/BaseField.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/base/BaseField.java
@@ -1,0 +1,51 @@
+/*
+ *   Copyright (C) 2020 Beijing Yishu Technology Co., Ltd.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.growingio.android.sdk.track.events.base;
+
+/**
+ * <p>
+ *
+ * @author cpacm 2022/8/8
+ */
+public class BaseField {
+    final static String PLATFORM = "platform";
+    final static String PLATFORM_VERSION = "platformVersion";
+    final static String USER_KEY = "userKey";
+    final static String USER_ID = "userId";
+    final static String SESSION_ID = "sessionId";
+    final static String EVENT_TYPE = "eventType";
+    final static String TIMESTAMP = "timestamp";
+    final static String DOMAIN = "domain";
+    final static String URL_SCHEME = "urlScheme";
+    final static String APP_STATE = "appState";
+    final static String GSID = "globalSequenceId";
+    final static String ESID = "eventSequenceId";
+    final static String DEVICE_ID = "deviceId";
+    public final static String NETWORK_STATE = "networkState";
+    public final static String APP_CHANNEl = "appChannel";
+    public final static String SCREEN_HEIGHT = "screenHeight";
+    public final static String SCREEN_WIDTH = "screenWidth";
+    public final static String DEVICE_BRAND = "deviceBrand";
+    public final static String DEVICE_MODEL = "deviceModel";
+    public final static String DEVICE_TYPE = "deviceType";
+    public final static String APP_NAME = "appName";
+    public final static String APP_VERSION = "appVersion";
+    public final static String LANGUAGE = "language";
+    public final static String LATITUDE = "latitude";
+    public final static String LONGITUDE = "longitude";
+    public final static String SDK_VERSION = "sdkVersion";
+}

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/helper/DefaultEventFilterInterceptor.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/helper/DefaultEventFilterInterceptor.java
@@ -54,7 +54,7 @@ public class DefaultEventFilterInterceptor implements EventFilterInterceptor {
         fieldArea.put(BaseField.DEVICE_MODEL, !FieldIgnoreFilter.isFieldFilter(BaseField.DEVICE_MODEL, getIgnoreField()));
         fieldArea.put(BaseField.DEVICE_TYPE, !FieldIgnoreFilter.isFieldFilter(BaseField.DEVICE_TYPE, getIgnoreField()));
 
-        fieldArea.put(BaseField.APP_CHANNEl, !FieldIgnoreFilter.isFieldFilter(BaseField.APP_CHANNEl, getIgnoreField()));
+        fieldArea.put(BaseField.APP_CHANNEL, !FieldIgnoreFilter.isFieldFilter(BaseField.APP_CHANNEL, getIgnoreField()));
         fieldArea.put(BaseField.APP_NAME, !FieldIgnoreFilter.isFieldFilter(BaseField.APP_NAME, getIgnoreField()));
         fieldArea.put(BaseField.APP_VERSION, !FieldIgnoreFilter.isFieldFilter(BaseField.APP_VERSION, getIgnoreField()));
         fieldArea.put(BaseField.LANGUAGE, !FieldIgnoreFilter.isFieldFilter(BaseField.LANGUAGE, getIgnoreField()));

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/helper/DefaultEventFilterInterceptor.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/helper/DefaultEventFilterInterceptor.java
@@ -1,0 +1,81 @@
+/*
+ *   Copyright (C) 2020 Beijing Yishu Technology Co., Ltd.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.growingio.android.sdk.track.events.helper;
+
+import com.growingio.android.sdk.track.events.EventFilterInterceptor;
+import com.growingio.android.sdk.track.events.base.BaseField;
+import com.growingio.android.sdk.track.providers.ConfigurationProvider;
+
+import java.util.Map;
+
+/**
+ * <p>
+ * SDK use DefaultEventFilterInterceptor to filter event.
+ *
+ * @author cpacm 2022/8/5
+ */
+public class DefaultEventFilterInterceptor implements EventFilterInterceptor {
+    @Override
+    public boolean filterEventType(String eventType) {
+        // 判断当前事件类型是否被过滤
+        return !EventExcludeFilter.isEventFilter(eventType, getExcludeEvent());
+    }
+
+    @Override
+    public boolean filterEventName(String eventName) {
+        return true;
+    }
+
+    @Override
+    public boolean filterEventPath(String path) {
+        return true;
+    }
+
+    @Override
+    public Map<String, Boolean> filterEventField(String type, Map<String, Boolean> fieldArea) {
+        fieldArea.put(BaseField.NETWORK_STATE, !FieldIgnoreFilter.isFieldFilter(BaseField.NETWORK_STATE, getIgnoreField()));
+        fieldArea.put(BaseField.SCREEN_HEIGHT, !FieldIgnoreFilter.isFieldFilter(BaseField.SCREEN_HEIGHT, getIgnoreField()));
+        fieldArea.put(BaseField.SCREEN_WIDTH, !FieldIgnoreFilter.isFieldFilter(BaseField.SCREEN_WIDTH, getIgnoreField()));
+        fieldArea.put(BaseField.DEVICE_BRAND, !FieldIgnoreFilter.isFieldFilter(BaseField.DEVICE_BRAND, getIgnoreField()));
+        fieldArea.put(BaseField.DEVICE_MODEL, !FieldIgnoreFilter.isFieldFilter(BaseField.DEVICE_MODEL, getIgnoreField()));
+        fieldArea.put(BaseField.DEVICE_TYPE, !FieldIgnoreFilter.isFieldFilter(BaseField.DEVICE_TYPE, getIgnoreField()));
+
+        fieldArea.put(BaseField.APP_CHANNEl, !FieldIgnoreFilter.isFieldFilter(BaseField.APP_CHANNEl, getIgnoreField()));
+        fieldArea.put(BaseField.APP_NAME, !FieldIgnoreFilter.isFieldFilter(BaseField.APP_NAME, getIgnoreField()));
+        fieldArea.put(BaseField.APP_VERSION, !FieldIgnoreFilter.isFieldFilter(BaseField.APP_VERSION, getIgnoreField()));
+        fieldArea.put(BaseField.LANGUAGE, !FieldIgnoreFilter.isFieldFilter(BaseField.LANGUAGE, getIgnoreField()));
+        fieldArea.put(BaseField.LATITUDE, !FieldIgnoreFilter.isFieldFilter(BaseField.LATITUDE, getIgnoreField()));
+        fieldArea.put(BaseField.LONGITUDE, !FieldIgnoreFilter.isFieldFilter(BaseField.LONGITUDE, getIgnoreField()));
+        fieldArea.put(BaseField.SDK_VERSION, !FieldIgnoreFilter.isFieldFilter(BaseField.SDK_VERSION, getIgnoreField()));
+        return fieldArea;
+    }
+
+    @Override
+    public boolean filterEventGroup(String group) {
+        return true;
+    }
+
+    @Deprecated
+    protected int getIgnoreField() {
+        return ConfigurationProvider.core().getIgnoreField();
+    }
+
+    @Deprecated
+    protected int getExcludeEvent() {
+        return ConfigurationProvider.core().getExcludeEvent();
+    }
+}

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/helper/EventExcludeFilter.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/helper/EventExcludeFilter.java
@@ -65,14 +65,32 @@ public final class EventExcludeFilter {
     public static final int VIEW_CHANGE = 1 << 9;
     public static final int FORM_SUBMIT = 1 << 10;
     public static final int REENGAGE = 1 << 11;
+    public static final int ACTIVATE = 1 << 12;
     public static final int EVENT_MASK_TRIGGER = (VIEW_CLICK | VIEW_CHANGE | FORM_SUBMIT);
+
+
+    public static final String EVENT_VISIT = TrackEventType.VISIT;
+    public static final String EVENT_CUSTOM = TrackEventType.CUSTOM;
+    public static final String EVENT_VISITOR_ATTRIBUTES = TrackEventType.VISITOR_ATTRIBUTES;
+    public static final String EVENT_LOGIN_USER_ATTRIBUTES = TrackEventType.LOGIN_USER_ATTRIBUTES;
+    public static final String EVENT_CONVERSION_VARIABLES = TrackEventType.CONVERSION_VARIABLES;
+    public static final String EVENT_APP_CLOSED = TrackEventType.APP_CLOSED;
+    public static final String EVENT_PAGE = AutotrackEventType.PAGE;
+    public static final String EVENT_PAGE_ATTRIBUTES = AutotrackEventType.PAGE_ATTRIBUTES;
+    public static final String EVENT_VIEW_CLICK = AutotrackEventType.VIEW_CLICK;
+    public static final String EVENT_VIEW_CHANGE = AutotrackEventType.VIEW_CHANGE;
+    public static final String EVENT_FORM_SUBMIT = "FORM_SUBMIT";
+    public static final String EVENT_REENGAGE = "REENGAGE";
+    public static final String EVENT_ACTIVATE = "ACTIVATE";
+
 
     //"FORM_SUBMIT" from Hybrid Module
     //"REENGAGE" is future's feature
     private static final ArrayList<String> EVENT_TYPE_LIST = new ArrayList<>(
             Arrays.asList(TrackEventType.VISIT, TrackEventType.CUSTOM, TrackEventType.VISITOR_ATTRIBUTES, TrackEventType.LOGIN_USER_ATTRIBUTES,
                     TrackEventType.CONVERSION_VARIABLES, TrackEventType.APP_CLOSED, AutotrackEventType.PAGE, AutotrackEventType.PAGE_ATTRIBUTES, AutotrackEventType.VIEW_CLICK,
-                    AutotrackEventType.VIEW_CHANGE, "FORM_SUBMIT", "REENGAGE"));
+                    AutotrackEventType.VIEW_CHANGE, "FORM_SUBMIT", "REENGAGE", "ACTIVATE"));
+
 
     private EventExcludeFilter() {
     }
@@ -92,8 +110,17 @@ public final class EventExcludeFilter {
         return EVENT_TYPE_LIST.contains(typeName) ? (1 << EVENT_TYPE_LIST.indexOf(typeName)) : 0;
     }
 
+
+    @Deprecated
     public static boolean isEventFilter(String typeName) {
         int filterFlag = ConfigurationProvider.core().getExcludeEvent();
+        if (filterFlag > 0) {
+            return (filterFlag & valueOf(typeName)) > 0;
+        }
+        return false;
+    }
+
+    public static boolean isEventFilter(String typeName, int filterFlag) {
         if (filterFlag > 0) {
             return (filterFlag & valueOf(typeName)) > 0;
         }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/helper/FieldIgnoreFilter.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/helper/FieldIgnoreFilter.java
@@ -18,6 +18,7 @@ package com.growingio.android.sdk.track.events.helper;
 
 import androidx.annotation.IntDef;
 
+import com.growingio.android.sdk.track.events.base.BaseField;
 import com.growingio.android.sdk.track.providers.ConfigurationProvider;
 
 import java.lang.annotation.Retention;
@@ -53,7 +54,7 @@ public class FieldIgnoreFilter {
     public static final int FIELD_IGNORE_ALL = (NETWORK_STATE | SCREEN_HEIGHT | SCREEN_WIDTH | DEVICE_BRAND | DEVICE_MODEL | DEVICE_TYPE);
 
     private static final ArrayList<String> FIELD_NAME_LIST = new ArrayList<>(
-            Arrays.asList("networkState", "screenHeight", "screenWidth", "deviceBrand", "deviceModel", "deviceType"));
+            Arrays.asList(BaseField.NETWORK_STATE, BaseField.SCREEN_HEIGHT, BaseField.SCREEN_WIDTH, BaseField.DEVICE_BRAND, BaseField.DEVICE_MODEL, BaseField.DEVICE_TYPE));
 
     private FieldIgnoreFilter() {
     }
@@ -73,8 +74,17 @@ public class FieldIgnoreFilter {
         return FIELD_NAME_LIST.contains(typeName) ? (1 << FIELD_NAME_LIST.indexOf(typeName)) : 0;
     }
 
+    @Deprecated
     public static boolean isFieldFilter(String typeName) {
         int ignoreFieldsFlag = ConfigurationProvider.core().getIgnoreField();
+        if (ignoreFieldsFlag > 0) {
+            int fieldMask = valueOf(typeName);
+            return (ignoreFieldsFlag & fieldMask) > 0;
+        }
+        return false;
+    }
+
+    public static boolean isFieldFilter(String typeName, int ignoreFieldsFlag) {
         if (ignoreFieldsFlag > 0) {
             int fieldMask = valueOf(typeName);
             return (ignoreFieldsFlag & fieldMask) > 0;

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/DeviceUtil.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/DeviceUtil.java
@@ -41,6 +41,7 @@ public class DeviceUtil {
 
     public static boolean isPhone(Context context) {
         TelephonyManager telephony = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
+        if (telephony == null) return true;
         int type = telephony.getPhoneType();
         return type != TelephonyManager.PHONE_TYPE_NONE;
     }

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/TrackerTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/TrackerTest.java
@@ -23,6 +23,8 @@ import android.webkit.WebView;
 
 import androidx.test.core.app.ApplicationProvider;
 
+import com.growingio.android.sdk.track.events.CustomEvent;
+import com.growingio.android.sdk.track.events.LoginUserAttributesEvent;
 import com.growingio.android.sdk.track.modelloader.TrackerRegistry;
 
 import org.junit.Test;
@@ -72,12 +74,36 @@ public class TrackerTest {
         WebView webView = new WebView(application);
         tracker.bridgeWebView(webView);
 
+        tracker.setLoginUserId("cpacm");
+        tracker.setLoginUserId("cpacm", "username");
+        tracker.cleanLoginUserId();
+
+        tracker.setLoginUserAttributesWithAttrBuilder(LoginUserAttributesEvent.AttributesBuilder.getAttributesBuilder().addAttribute("age", "18"));
+        tracker.trackCustomEventWithAttrBuilder("custom", CustomEvent.AttributesBuilder.getAttributesBuilder().addAttribute("name", "custom"));
+
         TestLibraryGioModule testLibraryGioModule = new TestLibraryGioModule();
         testLibraryGioModule.registerComponents(application, TrackerContext.get().getRegistry());
         testLibraryGioModule.getConfiguration(TestLibraryGioModule.class);
 
         tracker.registerComponent(testLibraryGioModule);
     }
+
+    @Test
+    public void coreConfiguration() {
+        CoreConfiguration coreConfiguration = new CoreConfiguration("TrackerTest", "growingio://tracker");
+        coreConfiguration.setDataCollectionServerHost("https://www.growingio.com/");
+        coreConfiguration.setDataCollectionEnabled(true);
+        coreConfiguration.setChannel("origin");
+        coreConfiguration.setUploadExceptionEnabled(false);
+        coreConfiguration.setDebugEnabled(true);
+        coreConfiguration.setCellularDataLimit(100);
+        coreConfiguration.setDataUploadInterval(100);
+        coreConfiguration.setSessionInterval(100);
+        coreConfiguration.setRequireAppProcessesEnabled(false);
+        coreConfiguration.setIdMappingEnabled(false);
+        coreConfiguration.addPreloadComponent(null);
+    }
+
 
     public static class TestLibraryGioModule extends LibraryGioModule implements Configurable {
         @Override

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/CdpTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/CdpTest.java
@@ -59,7 +59,7 @@ public class CdpTest {
         TrackerContext.init(application);
         Tracker tracker = new Tracker(application);
         tracker.setLoginUserId("cpacm");
-        trackMainThread = new TrackMainThread(new CoreConfiguration("CdpTest","growingio://cdp"));
+        trackMainThread = new TrackMainThread(new CoreConfiguration("CdpTest", "growingio://cdp"));
         trackMainThread.addEventBuildInterceptor(new EventBuildInterceptor() {
             @Override
             public void eventWillBuild(BaseEvent.BaseBuilder<?> eventBuilder) {

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/TrackMainFilterTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/TrackMainFilterTest.java
@@ -39,9 +39,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
@@ -77,7 +75,7 @@ public class TrackMainFilterTest {
 
         @Override
         public boolean filterEventName(String eventName) {
-            return !eventName.equals("gio");
+            return !"gio".equals(eventName);
         }
     }
 

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/events/helper/FilterTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/events/helper/FilterTest.java
@@ -55,12 +55,14 @@ public class FilterTest {
 
     @Test
     public void eventFilterTest() {
+        Truth.assertThat(EventExcludeFilter.isEventFilter("VIEW_CLICK", EventExcludeFilter.VIEW_CLICK)).isTrue();
         Truth.assertThat(EventExcludeFilter.isEventFilter("VIEW_CLICK")).isTrue();
         Truth.assertThat(EventExcludeFilter.isEventFilter("VIEW_CHANGE")).isTrue();
         Truth.assertThat(EventExcludeFilter.isEventFilter("PAGE")).isTrue();
         Truth.assertThat(EventExcludeFilter.isEventFilter("CUSTOM")).isFalse();
         Truth.assertThat(EventExcludeFilter.of(EventExcludeFilter.APP_CLOSED, EventExcludeFilter.PAGE)).isEqualTo(96);
         Truth.assertThat(EventExcludeFilter.isEventFilter("cpacm")).isFalse();
+        Truth.assertThat(EventExcludeFilter.isEventFilter("cpacm", EventExcludeFilter.VIEW_CLICK)).isFalse();
 
         String eventFilterLog = EventExcludeFilter.getEventFilterLog(12);
         Truth.assertThat(eventFilterLog).contains("VISITOR_ATTRIBUTES");
@@ -75,10 +77,12 @@ public class FilterTest {
     @Test
     public void filedFilterTest() {
         Truth.assertThat(FieldIgnoreFilter.isFieldFilter("screenWidth")).isTrue();
+        Truth.assertThat(FieldIgnoreFilter.isFieldFilter("screenWidth", FieldIgnoreFilter.SCREEN_WIDTH)).isTrue();
         Truth.assertThat(FieldIgnoreFilter.isFieldFilter("screenHeight")).isTrue();
         Truth.assertThat(FieldIgnoreFilter.isFieldFilter("deviceBrand")).isTrue();
         Truth.assertThat(FieldIgnoreFilter.isFieldFilter("deviceType")).isFalse();
         Truth.assertThat(FieldIgnoreFilter.isFieldFilter("getGIO")).isFalse();
+        Truth.assertThat(FieldIgnoreFilter.isFieldFilter("getGIO", FieldIgnoreFilter.SCREEN_WIDTH)).isFalse();
         Truth.assertThat(FieldIgnoreFilter.of(FieldIgnoreFilter.NETWORK_STATE, FieldIgnoreFilter.DEVICE_MODEL)).isEqualTo(17);
         Truth.assertThat((FieldIgnoreFilter.of(FieldIgnoreFilter.FIELD_IGNORE_ALL))).isEqualTo(63);
 

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/events/helper/FilterTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/events/helper/FilterTest.java
@@ -24,7 +24,6 @@ import com.google.common.truth.Truth;
 import com.growingio.android.sdk.CoreConfiguration;
 import com.growingio.android.sdk.TrackerContext;
 import com.growingio.android.sdk.track.providers.ConfigurationProvider;
-import com.growingio.android.sdk.track.utils.ConstantPool;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -44,8 +43,8 @@ public class FilterTest {
     public void setup() {
         TrackerContext.init(application);
         ConfigurationProvider.initWithConfig(
-                new CoreConfiguration("test", ConstantPool.UNKNOWN)
-                        .setProject("event", "filter")
+                new CoreConfiguration("FilterTest", "growingio://filter")
+                        .setProject("FilterTest", "growingio://filter")
                         .setExcludeEvent(EventExcludeFilter.VIEW_CLICK)
                         .setExcludeEvent(EventExcludeFilter.PAGE)
                         .setExcludeEvent(EventExcludeFilter.EVENT_MASK_TRIGGER)

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/events/helper/FilterTest2.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/events/helper/FilterTest2.java
@@ -1,0 +1,188 @@
+/*
+ *   Copyright (C) 2020 Beijing Yishu Technology Co., Ltd.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.growingio.android.sdk.track.events.helper;
+
+import android.app.Application;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.google.common.truth.Truth;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.growingio.android.sdk.CoreConfiguration;
+import com.growingio.android.sdk.TrackerContext;
+import com.growingio.android.sdk.track.TrackMainThread;
+import com.growingio.android.sdk.track.events.AutotrackEventType;
+import com.growingio.android.sdk.track.events.CustomEvent;
+import com.growingio.android.sdk.track.events.EventBuildInterceptor;
+import com.growingio.android.sdk.track.events.PageAttributesEvent;
+import com.growingio.android.sdk.track.events.PageEvent;
+import com.growingio.android.sdk.track.events.base.BaseEvent;
+import com.growingio.android.sdk.track.events.base.BaseField;
+import com.growingio.android.sdk.track.middleware.GEvent;
+import com.growingio.android.sdk.track.providers.ConfigurationProvider;
+import com.growingio.android.sdk.track.utils.ConstantPool;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+public class FilterTest2 {
+
+    Application application = ApplicationProvider.getApplicationContext();
+    CustomEventFilterInterceptor eventFilterInterceptor;
+
+    static class CustomEventFilterInterceptor extends DefaultEventFilterInterceptor {
+
+        @Override
+        public boolean filterEventType(String eventType) {
+            if (eventType.equals(EventExcludeFilter.EVENT_PAGE)) return false;
+            if (eventType.equals(EventExcludeFilter.EVENT_VIEW_CLICK)) return false;
+            if (eventType.equals(EventExcludeFilter.EVENT_VIEW_CHANGE)) return false;
+            if (eventType.equals(EventExcludeFilter.EVENT_FORM_SUBMIT)) return false;
+            return true;
+        }
+
+        @Override
+        public Map<String, Boolean> filterEventField(String type, Map<String, Boolean> fieldArea) {
+            fieldArea.put(BaseField.SCREEN_HEIGHT, false);
+            fieldArea.put(BaseField.SCREEN_WIDTH, false);
+            fieldArea.put(BaseField.DEVICE_BRAND, false);
+            return fieldArea;
+        }
+
+        @Override
+        public boolean filterEventPath(String path) {
+            return !path.contains("MainActivity");
+        }
+
+        @Override
+        public boolean filterEventName(String eventName) {
+            return !eventName.equals("gio");
+        }
+    }
+
+    @Before
+    public void setup() {
+        TrackerContext.init(application);
+        eventFilterInterceptor = new CustomEventFilterInterceptor();
+        ConfigurationProvider.initWithConfig(
+                new CoreConfiguration("test", ConstantPool.UNKNOWN)
+                        .setProject("event", "filter")
+                        .setEventFilterInterceptor(eventFilterInterceptor), new HashMap<>());
+
+    }
+
+    @Test
+    public void filterEventType1() {
+        TrackMainThread.trackMain().addEventBuildInterceptor(new EventBuildInterceptor() {
+            @Override
+            public void eventWillBuild(BaseEvent.BaseBuilder<?> eventBuilder) {
+                Truth.assertThat(eventBuilder.getEventType()).isEqualTo(EventExcludeFilter.EVENT_PAGE);
+            }
+
+            @Override
+            public void eventDidBuild(GEvent event) {
+            }
+        });
+        TrackMainThread.trackMain().postEventToTrackMain(new PageEvent.Builder());
+    }
+
+    @Test
+    public void filterEventType2() {
+        TrackMainThread.trackMain().addEventBuildInterceptor(new EventBuildInterceptor() {
+            @Override
+            public void eventWillBuild(BaseEvent.BaseBuilder<?> eventBuilder) {
+                Truth.assertThat(eventBuilder.getEventType()).isEqualTo(EventExcludeFilter.EVENT_CUSTOM);
+            }
+
+            @Override
+            public void eventDidBuild(GEvent event) {
+                Truth.assertThat(event.getEventType()).isEqualTo(EventExcludeFilter.EVENT_CUSTOM);
+            }
+        });
+        TrackMainThread.trackMain().postEventToTrackMain(new CustomEvent.Builder().setEventName("cpacm"));
+    }
+
+    @Test
+    public void filterEventPath() {
+        TrackMainThread.trackMain().addEventBuildInterceptor(new EventBuildInterceptor() {
+            @Override
+            public void eventWillBuild(BaseEvent.BaseBuilder<?> eventBuilder) {
+                Truth.assertThat(eventBuilder.getEventType()).isEqualTo(EventExcludeFilter.EVENT_PAGE_ATTRIBUTES);
+            }
+
+            @Override
+            public void eventDidBuild(GEvent event) {
+                Truth.assertThat(event.getEventType()).isEqualTo(EventExcludeFilter.EVENT_PAGE_ATTRIBUTES);
+                Truth.assertThat(event.toString()).contains("/SubActivity");
+            }
+        });
+        TrackMainThread.trackMain().postEventToTrackMain(new PageAttributesEvent.Builder().setPath("/MainActivity"));
+        TrackMainThread.trackMain().postEventToTrackMain(new PageAttributesEvent.Builder().setPath("/SubActivity"));
+    }
+
+    @Test
+    public void filterEventName() {
+        TrackMainThread.trackMain().addEventBuildInterceptor(new EventBuildInterceptor() {
+            @Override
+            public void eventWillBuild(BaseEvent.BaseBuilder<?> eventBuilder) {
+                Truth.assertThat(eventBuilder.getEventType()).isEqualTo(EventExcludeFilter.EVENT_CUSTOM);
+            }
+
+            @Override
+            public void eventDidBuild(GEvent event) {
+                Truth.assertThat(event instanceof CustomEvent).isTrue();
+                CustomEvent customEvent = (CustomEvent) event;
+                Truth.assertThat(event.getEventType()).isEqualTo(EventExcludeFilter.EVENT_CUSTOM);
+                Truth.assertThat(customEvent.getEventName()).isEqualTo("cpacm");
+            }
+        });
+        TrackMainThread.trackMain().postEventToTrackMain(new CustomEvent.Builder().setEventName("gio"));
+        TrackMainThread.trackMain().postEventToTrackMain(new CustomEvent.Builder().setEventName("cpacm"));
+    }
+
+    @Test
+    public void filterEventField() {
+        TrackMainThread.trackMain().addEventBuildInterceptor(new EventBuildInterceptor() {
+            @Override
+            public void eventWillBuild(BaseEvent.BaseBuilder<?> eventBuilder) {
+                Truth.assertThat(eventBuilder.getEventType()).isEqualTo(EventExcludeFilter.EVENT_CUSTOM);
+            }
+
+            @Override
+            public void eventDidBuild(GEvent event) {
+                Truth.assertThat(event instanceof CustomEvent).isTrue();
+                CustomEvent customEvent = (CustomEvent) event;
+                Truth.assertThat(customEvent.getEventName()).isEqualTo("cpacm");
+                Truth.assertThat(customEvent.getScreenHeight()).isEqualTo(0);
+                Truth.assertThat(customEvent.getScreenWidth()).isEqualTo(0);
+                Truth.assertThat(customEvent.getDeviceBrand()).isNull();
+            }
+        });
+        TrackMainThread.trackMain().postEventToTrackMain(new CustomEvent.Builder().setEventName("cpacm"));
+        //Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+    }
+
+}

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/providers/ProviderTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/providers/ProviderTest.java
@@ -98,9 +98,9 @@ public class ProviderTest {
 
     @Test
     public void configProvider() {
-        ConfigurationProvider.initWithConfig(new CoreConfiguration("test", ConstantPool.UNKNOWN), new HashMap<>());
-        Truth.assertThat(ConfigurationProvider.core().getUrlScheme()).isEqualTo(ConstantPool.UNKNOWN);
-        ConfigurationProvider.initWithConfig(new CoreConfiguration("test", "test"), new HashMap<>());
+        ConfigurationProvider.initWithConfig(new CoreConfiguration("ProviderTest", "growingio://provider"), new HashMap<>());
+        Truth.assertThat(ConfigurationProvider.core().getUrlScheme()).isEqualTo("growingio://provider");
+        ConfigurationProvider.initWithConfig(new CoreConfiguration("ProviderTest", "growingio://provider"), new HashMap<>());
         TestConfigurable testConfigurable = new TestConfigurable();
         ConfigurationProvider.get().addConfiguration(testConfigurable);
         Truth.assertThat((TestConfigurable) ConfigurationProvider.get().getConfiguration(TestConfigurable.class)).isEqualTo(testConfigurable);
@@ -154,7 +154,7 @@ public class ProviderTest {
         Truth.assertThat(DeviceInfoProvider.get().getGoogleAdId()).isNull();
         Truth.assertThat(DeviceInfoProvider.get().getImei()).isNull();
         Truth.assertThat(DeviceInfoProvider.get().getOaid()).isNull();
-        Truth.assertThat(DeviceInfoProvider.get().getOperatingSystemVersion()).isEqualTo("11");
+        Truth.assertThat(DeviceInfoProvider.get().getOperatingSystemVersion()).isEqualTo("12");
         Truth.assertThat(DeviceInfoProvider.get().getScreenHeight()).isEqualTo(470);
         Truth.assertThat(DeviceInfoProvider.get().getScreenWidth()).isEqualTo(320);
         PersistentDataProvider.get().setDeviceId("");

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/providers/ProviderTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/providers/ProviderTest.java
@@ -31,7 +31,6 @@ import com.growingio.android.sdk.TrackerContext;
 import com.growingio.android.sdk.track.ipc.PersistentDataProvider;
 import com.growingio.android.sdk.track.listener.IActivityLifecycle;
 import com.growingio.android.sdk.track.listener.event.ActivityLifecycleEvent;
-import com.growingio.android.sdk.track.utils.ConstantPool;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/utils/UtilsTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/utils/UtilsTest.java
@@ -39,14 +39,17 @@ import com.growingio.android.sdk.track.providers.RobolectricActivity;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
 
 import java.util.Map;
 
+@Config
 @RunWith(RobolectricTestRunner.class)
 public class UtilsTest {
 
@@ -121,6 +124,11 @@ public class UtilsTest {
     }
 
     Application application = ApplicationProvider.getApplicationContext();
+
+    @Before
+    public void setup() {
+        TrackerContext.init(application);
+    }
 
     @Test
     public void networkTest() {

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/view/ViewTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/view/ViewTest.java
@@ -52,7 +52,6 @@ public class ViewTest {
         ActivityStateProvider.get().onActivityResumed(activity);
         Truth.assertThat(WindowHelper.get().getTopActivityDecorView()).isEqualTo(activity.getWindow().getDecorView());
         List<DecorView> views = WindowHelper.get().getTopActivityViews();
-        System.out.println(views.size());
         views.forEach(new Consumer<DecorView>() {
             @Override
             public void accept(DecorView decorView) {

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/webservice/WebServiceTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/webservice/WebServiceTest.java
@@ -26,13 +26,9 @@ import android.view.WindowManager;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.growingio.android.sdk.TrackerContext;
-import com.growingio.android.sdk.track.SDKConfig;
 import com.growingio.android.sdk.track.log.LogItem;
 import com.growingio.android.sdk.track.log.Logger;
-import com.growingio.android.sdk.track.providers.AppInfoProvider;
-import com.growingio.android.sdk.track.providers.DeviceInfoProvider;
 import com.growingio.android.sdk.track.providers.RobolectricActivity;
-import com.growingio.android.sdk.track.utils.ConstantPool;
 import com.growingio.android.sdk.track.webservices.Circler;
 import com.growingio.android.sdk.track.webservices.Debugger;
 import com.growingio.android.sdk.track.middleware.advert.DeepLink;

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/webservice/WebServiceTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/webservice/WebServiceTest.java
@@ -16,6 +16,7 @@
 
 package com.growingio.android.sdk.track.webservice;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Application;
 import android.net.Uri;
@@ -25,16 +26,24 @@ import android.view.WindowManager;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.growingio.android.sdk.TrackerContext;
+import com.growingio.android.sdk.track.SDKConfig;
+import com.growingio.android.sdk.track.log.LogItem;
 import com.growingio.android.sdk.track.log.Logger;
+import com.growingio.android.sdk.track.providers.AppInfoProvider;
+import com.growingio.android.sdk.track.providers.DeviceInfoProvider;
 import com.growingio.android.sdk.track.providers.RobolectricActivity;
+import com.growingio.android.sdk.track.utils.ConstantPool;
 import com.growingio.android.sdk.track.webservices.Circler;
 import com.growingio.android.sdk.track.webservices.Debugger;
 import com.growingio.android.sdk.track.middleware.advert.DeepLink;
+import com.growingio.android.sdk.track.webservices.log.LoggerDataMessage;
 import com.growingio.android.sdk.track.webservices.log.WsLogger;
+import com.growingio.android.sdk.track.webservices.message.ClientInfoMessage;
 import com.growingio.android.sdk.track.webservices.message.QuitMessage;
 import com.growingio.android.sdk.track.webservices.message.ReadyMessage;
 import com.growingio.android.sdk.track.webservices.widget.TipView;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,7 +51,9 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -55,6 +66,7 @@ public class WebServiceTest {
     public void logTest() {
         WsLogger wsLogger = new WsLogger();
         wsLogger.setCallback(new WsLogger.Callback() {
+            @SuppressLint("CheckResult")
             @Override
             public void disposeLog(String logMessage) {
                 assertThat(logMessage.contains("this is test log"));
@@ -65,19 +77,32 @@ public class WebServiceTest {
         wsLogger.closeLog();
         wsLogger.printOut();
         wsLogger.setCallback(null);
+
     }
 
     Application application = ApplicationProvider.getApplicationContext();
 
     @Test
-    public void messageTest() {
+    public void messageTest() throws JSONException {
         JSONObject quit = new QuitMessage().toJSONObject();
         assertThat(quit.opt("msgType")).isEqualTo("quit");
 
         TrackerContext.init(application);
         JSONObject ready = ReadyMessage.createMessage().toJSONObject();
         assertThat(ready.opt("msgType")).isEqualTo("ready");
+
+        ClientInfoMessage info = ClientInfoMessage.createMessage();
+        assertThat(info.toJSONObject().opt("msgType")).isEqualTo("client_info");
+
+        LogItem logItem = new LogItem.Builder().setMessage("webService")
+                .setPriority(0).setTag("webservice").setThrowable(null).setTimeStamp(0L).build();
+        List<LogItem> list = new ArrayList<>();
+        list.add(logItem);
+        LoggerDataMessage message = LoggerDataMessage
+                .createTrackMessage(list);
+        assertThat(message.toJSONObject().optJSONArray("data").getJSONObject(0).opt("message")).isEqualTo("webService");
     }
+
 
     @Test
     public void tipTest() {
@@ -88,7 +113,6 @@ public class WebServiceTest {
         windowManager.addView(tipView, new WindowManager.LayoutParams());
         tipView.setContent("this is test tip");
         tipView.setErrorMessage("this is test error");
-        int height = tipView.getStatusBarHeight();
 
         tipView.onTouchEvent(MotionEvent.obtain(System.currentTimeMillis(),
                 System.currentTimeMillis() + 100L,
@@ -112,7 +136,7 @@ public class WebServiceTest {
         Debugger debugger = new Debugger(new HashMap<>());
         assertThat(debugger.getParams().size()).isEqualTo(0);
         DeepLink deepLink = new DeepLink(Uri.parse("growingio://cpacm?name=cpacm"));
-        assertThat(deepLink.toString()).contains("name=cpacm");
+        assertThat(deepLink.getUri().toString()).contains("name=cpacm");
     }
 
 }


### PR DESCRIPTION
## PR 内容

重新编写事件过滤的方式，支持：
事件类型，事件名称，事件路径。
同时支持事件属性的过滤。

## 测试步骤
1. 测试上述功能在新版本能够正常使用；
2. 测试老接口 setExcludeEvent 和 setIgnoreField 能否正常使用；


## 影响范围
事件过滤

## 是否属于重要变动？

- [x] 是
- [ ] 否

## 其他信息
先测CI，然后会修改合并至广告分支上