### PR TITLE
fix:将sessionid的设置提前到setup过程中

### DIFF
--- a/demos/demo/src/main/java/com/gio/test/three/DemoApplication.java
+++ b/demos/demo/src/main/java/com/gio/test/three/DemoApplication.java
@@ -99,6 +99,7 @@ public class DemoApplication extends Application {
         long startTime = System.currentTimeMillis();
         GrowingAutotracker.startWithConfiguration(this, sConfiguration);
         Log.d(TAG, "start time: " + (System.currentTimeMillis() - startTime));
+
     }
 
     private boolean isMainProcess() {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
@@ -107,6 +107,13 @@ public class Tracker {
         TrackEventGenerator.generateCustomEvent(eventName, attributes);
     }
 
+    /**
+     * @see #trackCustomEvent(String, Map)
+     * <code>
+     * trackCustomEvent(eventName,new AttributesBuilder().build())
+     * </code>
+     */
+    @Deprecated
     public void trackCustomEventWithAttrBuilder(String eventName, CustomEvent.AttributesBuilder attributesBuilder) {
         if (!isInited) return;
         if (TextUtils.isEmpty(eventName)) {
@@ -135,6 +142,13 @@ public class Tracker {
         TrackEventGenerator.generateLoginUserAttributesEvent(new HashMap<>(attributes));
     }
 
+    /**
+     * @see #setLoginUserAttributes(Map)
+     * <code>
+     * setLoginUserAttributes(new AttributesBuilder().build())
+     * </code>
+     */
+    @Deprecated
     public void setLoginUserAttributesWithAttrBuilder(LoginUserAttributesEvent.AttributesBuilder attributesBuilder) {
         if (!isInited) return;
         Map<String, String> attributes = attributesBuilder.getAttributes();

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
@@ -75,6 +75,7 @@ public class Tracker {
         application.registerActivityLifecycleCallbacks(ActivityStateProvider.get());
         DeepLinkProvider.get().init();
         SessionProvider.get().init();
+        PersistentDataProvider.get().setup();
 
         loadAnnotationGeneratedModules(application);
         // 支持配置中注册模块, 如加密模块等事件模块需要先于所有事件发送注册

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/AttributesBuilder.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/AttributesBuilder.java
@@ -1,0 +1,150 @@
+/*
+ *   Copyright (C) 2020 Beijing Yishu Technology Co., Ltd.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.growingio.android.sdk.track.events;
+
+import android.util.SparseArray;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * <p>
+ * 用于构建事件的属性
+ *
+ * @author cpacm 2022/8/19
+ */
+public class AttributesBuilder {
+
+    Map<String, String> attributes;
+    private static final String LIST_SPLIT = "||";
+
+    public AttributesBuilder() {
+        this.attributes = new HashMap<>();
+    }
+
+    public AttributesBuilder addAttribute(String key, String value) {
+        if (key != null && value != null) {
+            attributes.put(key, value);
+        }
+
+        return this;
+    }
+
+    public <T> AttributesBuilder addAttribute(String key, List<T> value) {
+        if (key != null && value != null && !value.isEmpty()) {
+            StringBuilder valueBuilder = new StringBuilder();
+            Iterator<T> iterator = value.iterator();
+            if (iterator.hasNext()) {
+                valueBuilder.append(toString(iterator.next()));
+                while (iterator.hasNext()) {
+                    valueBuilder.append(LIST_SPLIT);
+                    valueBuilder.append(toString(iterator.next()));
+                }
+            }
+            attributes.put(key, valueBuilder.toString());
+        }
+
+        return this;
+    }
+
+    /**
+     * support string array only
+     */
+    public <T> AttributesBuilder addAttribute(String key, JSONArray array) {
+        if (key != null && array != null && array.length() > 0) {
+            List<String> valueList = new ArrayList<>();
+            try {
+                for (int i = 0; i < array.length(); i++) {
+                    Object value = array.get(i);
+                    if (value instanceof String) {
+                        valueList.add(String.valueOf(value));
+                    }
+                }
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+            return addAttribute(key, valueList);
+        }
+        return this;
+    }
+
+    public <T> AttributesBuilder addAttribute(String key, SparseArray<T> array) {
+        if (key != null && array != null && array.size() > 0) {
+            List<String> valueList = new ArrayList<>();
+            for (int i = 0; i < array.size(); i++) {
+                T value = array.valueAt(i);
+                valueList.add(String.valueOf(value));
+
+            }
+            return addAttribute(key, valueList);
+        }
+        return this;
+    }
+
+    public <T> AttributesBuilder addAttribute(String key, Set<T> array) {
+        if (key != null && array != null && array.size() > 0) {
+            StringBuilder valueBuilder = new StringBuilder();
+            Iterator<T> iterator = array.iterator();
+            if (iterator.hasNext()) {
+                valueBuilder.append(toString(iterator.next()));
+                while (iterator.hasNext()) {
+                    valueBuilder.append(LIST_SPLIT);
+                    valueBuilder.append(toString(iterator.next()));
+                }
+            }
+            attributes.put(key, valueBuilder.toString());
+        }
+        return this;
+    }
+
+    public AttributesBuilder addAttribute(String key, String[] array) {
+        if (key != null && array != null && array.length > 0) {
+            StringBuilder valueBuilder = new StringBuilder();
+            for (int i = 0; i < array.length; i++) {
+                valueBuilder.append(array[i]);
+                if (i < array.length - 1) {
+                    valueBuilder.append(LIST_SPLIT);
+                }
+            }
+            return addAttribute(key, valueBuilder.toString());
+        }
+        return this;
+    }
+
+
+    private String toString(Object value) {
+        if (value == null) {
+            return "";
+        } else {
+            return String.valueOf(value);
+        }
+    }
+
+    public Map<String, String> build() {
+        if (attributes == null || attributes.isEmpty()) {
+            return null;
+        }
+        return attributes;
+    }
+}

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/CustomEvent.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/CustomEvent.java
@@ -21,8 +21,6 @@ import com.growingio.android.sdk.track.events.base.BaseAttributesEvent;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -80,11 +78,10 @@ public class CustomEvent extends BaseAttributesEvent {
     }
 
     public static class AttributesBuilder {
-        Map<String, String> attributes;
-        private static final String LIST_SPLIT = "||";
+        private final com.growingio.android.sdk.track.events.AttributesBuilder builder;
 
         private AttributesBuilder() {
-            attributes = new HashMap<>();
+            builder = new com.growingio.android.sdk.track.events.AttributesBuilder();
         }
 
         public static AttributesBuilder getAttributesBuilder() {
@@ -92,43 +89,17 @@ public class CustomEvent extends BaseAttributesEvent {
         }
 
         public AttributesBuilder addAttribute(String key, String value) {
-            if (key != null && value != null) {
-                attributes.put(key, value);
-            }
-
+            builder.addAttribute(key, value);
             return this;
         }
 
         public <T> AttributesBuilder addAttribute(String key, List<T> value) {
-            if (key != null && value != null && !value.isEmpty()) {
-                StringBuilder valueBuilder = new StringBuilder();
-                Iterator<T> iterator = value.iterator();
-                if (iterator.hasNext()) {
-                    valueBuilder.append(toString(iterator.next()));
-                    while (iterator.hasNext()) {
-                        valueBuilder.append(LIST_SPLIT);
-                        valueBuilder.append(toString(iterator.next()));
-                    }
-                }
-                attributes.put(key, valueBuilder.toString());
-            }
-
+            builder.addAttribute(key, value);
             return this;
         }
 
         public Map<String, String> getAttributes() {
-            if (attributes == null || attributes.isEmpty()) {
-                return null;
-            }
-            return attributes;
-        }
-
-        private String toString(Object value) {
-            if (value == null) {
-                return "";
-            } else {
-                return String.valueOf(value);
-            }
+            return builder.build();
         }
     }
 }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/LoginUserAttributesEvent.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/LoginUserAttributesEvent.java
@@ -18,8 +18,6 @@ package com.growingio.android.sdk.track.events;
 
 import com.growingio.android.sdk.track.events.base.BaseAttributesEvent;
 
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -53,11 +51,10 @@ public final class LoginUserAttributesEvent extends BaseAttributesEvent {
     }
 
     public static class AttributesBuilder {
-        Map<String, String> attributes;
-        private static final String LIST_SPLIT = "||";
+        private final com.growingio.android.sdk.track.events.AttributesBuilder builder;
 
         private AttributesBuilder() {
-            attributes = new HashMap<>();
+            builder = new com.growingio.android.sdk.track.events.AttributesBuilder();
         }
 
         public static AttributesBuilder getAttributesBuilder() {
@@ -65,40 +62,17 @@ public final class LoginUserAttributesEvent extends BaseAttributesEvent {
         }
 
         public AttributesBuilder addAttribute(String key, String value) {
-            if (key != null && value != null) {
-                attributes.put(key, value);
-            }
-
+            builder.addAttribute(key, value);
             return this;
         }
 
         public <T> AttributesBuilder addAttribute(String key, List<T> value) {
-            if (key != null && value != null && !value.isEmpty()) {
-                StringBuilder valueBuilder = new StringBuilder();
-                Iterator<T> iterator = value.iterator();
-                if (iterator.hasNext()) {
-                    valueBuilder.append(toString(iterator.next()));
-                    while (iterator.hasNext()) {
-                        valueBuilder.append(LIST_SPLIT);
-                        valueBuilder.append(toString(iterator.next()));
-                    }
-                }
-                attributes.put(key, valueBuilder.toString());
-            }
-
+            builder.addAttribute(key, value);
             return this;
         }
 
         public Map<String, String> getAttributes() {
-            return attributes;
-        }
-
-        private String toString(Object value) {
-            if (value == null) {
-                return "";
-            } else {
-                return String.valueOf(value);
-            }
+            return builder.build();
         }
     }
 }


### PR DESCRIPTION
## PR 内容
为了保证模块发送事件时能够拿到sessionid,
将sessionid的设置提前到setup过程中

## 测试步骤

模块中的session不为空


## 是否属于重要变动？

- [ ] 是
- [x] 否
