### PR TITLE
fix: negative array

### DIFF
--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/MultiProcessDataSharer.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/MultiProcessDataSharer.java
@@ -124,7 +124,7 @@ public class MultiProcessDataSharer implements IDataSharer {
         }
     }
 
-    //位置校验，在SharedEntry构造函数中，如果该位置没值则会抛出异常
+    // 位置校验，在SharedEntry构造函数中，如果该位置没值或值非法则会抛出异常
     private void incrementLoadFromDisk() {
         int surplus = mMaxSize - mSharedEntries.size();
         for (int i = 0; i < surplus; i++) {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/PersistentDataProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/PersistentDataProvider.java
@@ -43,6 +43,7 @@ public class PersistentDataProvider {
     private static final String SHARER_NAME = "PersistentSharerDataProvider";
     private static final int SHARER_MAX_SIZE = 50;
 
+    // Key长度校验 0 <= len < 50, 判断文件读取是否合法
     private static final String KEY_TYPE_GLOBAL = "TYPE_GLOBAL";
     private static final String KEY_LOGIN_USER_KEY = "LOGIN_USER_KEY";
     private static final String KEY_LOGIN_USER_ID = "LOGIN_USER_ID";

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/SharedEntry.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/ipc/SharedEntry.java
@@ -57,7 +57,8 @@ class SharedEntry {
         mPosition = position;
         byteBuffer.position(mPosition);
         short keyLength = byteBuffer.getShort();
-        if (keyLength == 0) {
+        // 低概率抛出异常 java.lang.NegativeArraySizeException -22345
+        if (keyLength <= 0 || keyLength > 50) {
             throw new IllegalArgumentException("This position is not valid");
         }
         byte[] bytes = new byte[keyLength];


### PR DESCRIPTION
## PR 内容
java.lang.NegativeArraySizeException -22345
```shell
16809-22 15:18:33.896 22653 22885 E TRACK.EventDataManager: removeOverdueEvents: deleteNum: 0
16909-22 15:18:33.901 22653 22892 E AndroidRuntime: FATAL EXCEPTION: MultiProcessDataSharer-load
17009-22 15:18:33.901 22653 22892 E AndroidRuntime: Process: com.transsnet.palmpay, PID: 22653
17109-22 15:18:33.901 22653 22892 E AndroidRuntime: java.lang.NegativeArraySizeException: -22345
17209-22 15:18:33.901 22653 22892 E AndroidRuntime: at com.growingio.android.sdk.track.ipc.e.<init>(SharedEntry.java:5)
17309-22 15:18:33.901 22653 22892 E AndroidRuntime: at com.growingio.android.sdk.track.ipc.b.i(MultiProcessDataSharer.java:2)
17409-22 15:18:33.901 22653 22892 E AndroidRuntime: at com.growingio.android.sdk.track.ipc.b.k(MultiProcessDataSharer.java:9)
17509-22 15:18:33.901 22653 22892 E AndroidRuntime: at com.growingio.android.sdk.track.ipc.b.a(MultiProcessDataSharer.java:1)
17609-22 15:18:33.901 22653 22892 E AndroidRuntime: at com.growingio.android.sdk.track.ipc.b$a.run(MultiProcessDataSharer.java:1)
```


## 测试步骤
推送非法文件替换 /data/data/{packagename}/files/PersistentSharerDataProvider.shared
可以使用[ImHex](https://github.com/WerWolv/ImHex)或010Editor查看和修改二进制文件
比如将最开始的两个字符00 09（一般存储的是ALIVE_PID，改为任意非法字符）
通过adb push PersistentSharerDataProvider.shared /data/data/{packagename}/files/PersistentSahrerDataProvider.shared替换原文件，再次启动app，然后将文件获取后查看对应字符恢复为00 09（adb pull /data/data/com.gio.test.three/files/PersistentSharerDataProvider.shared ~/Desktop）
无权限的情况下使用adb root

## 影响范围

<!-- 请描述你的PR能造成的影响范围. -->


## 是否属于重要变动？

- [ ] 是
- [x] 否


## 其他信息


