### PR TITLE
fix:in multi process,after send events should release processLock.

### DIFF
--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/middleware/EventSender.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/middleware/EventSender.java
@@ -188,13 +188,13 @@ public class EventSender {
     }
 
     /**
-     * 发送事件
+     * 发送事件，为了保证单进程发送数据，获取进程锁后不再释放 mProcessLock.release();
      *
      * @param onlyInstant true -- 仅发送实时消息
      */
     void sendEvents(boolean onlyInstant) {
         if (!mProcessLock.isAcquired()) {
-            Logger.e(TAG, "sendEvents: this process can not get lock");
+            Logger.w(TAG, "sdk sendEvents will in main process,not in sub process.");
             return;
         }
 
@@ -237,8 +237,6 @@ public class EventSender {
                 }
             } while (succeeded);
         }
-
-        mProcessLock.release();
     }
 
 

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/middleware/EventSender.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/middleware/EventSender.java
@@ -237,6 +237,8 @@ public class EventSender {
                 }
             } while (succeeded);
         }
+
+        mProcessLock.release();
     }
 
 


### PR DESCRIPTION
## PR 内容

多进程情况下，发送Event时出现 “sendEvents: this process can not get lock” 错误日志，导致事件无法发送。
修复：发送事件结束后释放获取到的进程文件锁。


## 测试步骤
1. 复现多进程下出现的如上错误日志；
2. 修复后不再出现以上错误日志


## 影响范围
除了主进程以外的事件发送。


## 是否属于重要变动？

- [x] 是
- [ ] 否


## 其他信息


