### PR TITLE
feat:通用属性

### DIFF
--- a/growingio-annotation/compiler/src/main/java/com/growingio/sdk/annotation/compiler/ConfigurationGenerator.kt
+++ b/growingio-annotation/compiler/src/main/java/com/growingio/sdk/annotation/compiler/ConfigurationGenerator.kt
@@ -197,10 +197,10 @@ internal class ConfigurationGenerator(
     ): MethodSpec {
         val methodSpec = MethodSpec.constructorBuilder()
             .addModifiers(Modifier.PUBLIC)
-            .addParameter(String::class.java, "projectId")
+            .addParameter(String::class.java, "accountId")
             .addParameter(String::class.java, "urlScheme")
             .addStatement(
-                "this.coreConfiguration = new \$T(projectId,urlScheme)",
+                "this.coreConfiguration = new \$T(accountId,urlScheme)",
                 coreConfigurationClass,
             )
 

--- a/growingio-annotation/compiler/src/test/resources/EmptyAppModuleTest/TestTrackConfiguration.java
+++ b/growingio-annotation/compiler/src/test/resources/EmptyAppModuleTest/TestTrackConfiguration.java
@@ -33,8 +33,8 @@ public final class TestTrackConfiguration {
 
     private final HashMap<Class<? extends Configurable>, Configurable> MODULE_CONFIGURATIONS = new HashMap<Class<? extends Configurable>, Configurable>();
 
-    public TestTrackConfiguration(String projectId, String urlScheme) {
-        this.coreConfiguration = new CoreConfiguration(projectId,urlScheme);
+    public TestTrackConfiguration(String accountId, String urlScheme) {
+        this.coreConfiguration = new CoreConfiguration(accountId,urlScheme);
         addConfiguration(new EmptyConfig());
     }
 

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/view/ViewNodeV4.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/view/ViewNodeV4.java
@@ -222,7 +222,7 @@ class ViewNodeV4 implements ViewNode {
         if (ListMenuItemViewShadow.isListMenuItemView(this.view)) {
             MenuItem menuItem = new ListMenuItemViewShadow(this.view).getMenuItem();
             if (menuItem != null) {
-                ViewNodeV4 itemViewNode = generateMenuItemViewNode(this.view.getContext(), menuItem);
+                ViewNodeV4 itemViewNode = generateMenuItemViewNode(this.view.getContext(), this.page, menuItem);
                 this.xPath = itemViewNode.getXPath();
                 this.index = itemViewNode.getIndex();
                 this.xIndex = itemViewNode.getXIndex();
@@ -306,7 +306,7 @@ class ViewNodeV4 implements ViewNode {
     }
 
 
-    public static ViewNodeV4 generateMenuItemViewNode(Context context, MenuItem menuItem) {
+    public static ViewNodeV4 generateMenuItemViewNode(Context context, Page page, MenuItem menuItem) {
         StringBuilder xpath = new StringBuilder();
         StringBuilder xIndex = new StringBuilder();
         String packageId = ViewAttributeUtil.getPackageId(context, menuItem.getItemId());
@@ -315,6 +315,7 @@ class ViewNodeV4 implements ViewNode {
 
         return new ViewNodeV4()
                 .setIndex(-1)
+                .setPage(page)
                 .setViewContent(menuItem.getTitle() != null ? menuItem.getTitle().toString() : null)
                 .setXPath(xpath.toString())
                 .setXIndex(xIndex.toString())

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/view/ViewNodeV4Renderer.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/view/ViewNodeV4Renderer.java
@@ -66,7 +66,7 @@ class ViewNodeV4Renderer implements ViewNodeRenderer {
     @Override
     public void generateMenuItemEvent(Activity activity, MenuItem menuItem) {
         Page<?> page = PageProvider.get().searchActivityPage(activity);
-        ViewNodeV4 viewNode = renderMenuItemViewNode(activity, menuItem);
+        ViewNodeV4 viewNode = renderMenuItemViewNode(activity, page, menuItem);
         if (page != null && viewNode != null) {
             StringBuilder xpath = new StringBuilder();
             StringBuilder xIndex = new StringBuilder();
@@ -88,8 +88,8 @@ class ViewNodeV4Renderer implements ViewNodeRenderer {
         }
     }
 
-    private ViewNodeV4 renderMenuItemViewNode(Context context, MenuItem menuItem) {
-        return ViewNodeV4.generateMenuItemViewNode(context, menuItem);
+    private ViewNodeV4 renderMenuItemViewNode(Context context, Page page, MenuItem menuItem) {
+        return ViewNodeV4.generateMenuItemViewNode(context, page, menuItem);
     }
 
     @Override
@@ -106,7 +106,7 @@ class ViewNodeV4Renderer implements ViewNodeRenderer {
 
         ViewNodeV4 viewNode = renderViewNode(view);
         if (viewNode != null) {
-            Page<?> page = PageProvider.get().findPage(view);
+            Page<?> page = viewNode.getPage();
             if (page == null) {
                 Logger.w(TAG, "sendClickEvent: page is NULL");
                 return;
@@ -160,7 +160,7 @@ class ViewNodeV4Renderer implements ViewNodeRenderer {
 
         ViewNodeV4 viewNode = renderViewNode(view);
         if (viewNode != null) {
-            Page<?> page = PageProvider.get().findPage(view);
+            Page<?> page = viewNode.getPage();
             if (page == null) {
                 Logger.w(TAG, "sendChangeEvent: page is NULL");
                 return;
@@ -198,9 +198,10 @@ class ViewNodeV4Renderer implements ViewNodeRenderer {
     ViewNodeV4 renderViewNode(View childView) {
         // judge Menu Item
         if (ListMenuItemViewShadow.isListMenuItemView(childView) && childView.getContext() != null) {
+            Page page = PageProvider.get().findPage(childView);
             MenuItem menuItem = new ListMenuItemViewShadow(childView).getMenuItem();
             if (menuItem != null) {
-                return renderMenuItemViewNode(childView.getContext(), menuItem);
+                return renderMenuItemViewNode(childView.getContext(), page, menuItem);
             }
         }
 
@@ -257,9 +258,10 @@ class ViewNodeV4Renderer implements ViewNodeRenderer {
             xIndex.append("/0");
         } else {
             String prefix = PageHelper.getWindowPrefix(rootView);
-            findPage = new WindowPage(prefix);
-            Page parentPage = PageProvider.get().findPage(rootView);
-            findPage.assignParent(parentPage);
+            findPage = PageProvider.get().findPage(rootView);
+            if (findPage == null) {
+                findPage = new WindowPage(prefix);
+            }
             // PopupDecorView 这个class是在Android 6.0的时候才引入的，为了兼容6.0以下的版本，需要手动添加这个class层级
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M && prefix.equals(PageHelper.POPUP_WINDOW_PREFIX) && !POPUP_DECOR_VIEW_CLASS_NAME.equals(ClassUtil.getSimpleClassName(rootView.getClass()))) {
                 xpath.append("/").append(POPUP_DECOR_VIEW_CLASS_NAME).append("/").append(ClassUtil.getSimpleClassName(rootView.getClass()));

--- a/growingio-autotracker-core/src/test/java/com/growingio/android/sdk/autotrack/view/ViewNodeV4Test.java
+++ b/growingio-autotracker-core/src/test/java/com/growingio/android/sdk/autotrack/view/ViewNodeV4Test.java
@@ -137,7 +137,7 @@ public class ViewNodeV4Test {
         MenuItem testItem = new RoboMenuItem().setTitle("test menu item")
                 .setActionView(testEt);
         activity.onContextItemSelected(testItem);
-        ViewNodeV4 pageNode = ViewNodeV4.generateMenuItemViewNode(activity, testItem);
+        ViewNodeV4 pageNode = ViewNodeV4.generateMenuItemViewNode(activity, new ActivityPage(activity), testItem);
         Truth.assertThat(pageNode.getXPath()).isEqualTo("/MenuView/MenuItem");
         Truth.assertThat(pageNode.getXIndex()).isEqualTo("/0/0");
 

--- a/growingio-hybrid/src/main/java/com/growingio/android/hybrid/HybridTransformerImp.java
+++ b/growingio-hybrid/src/main/java/com/growingio/android/hybrid/HybridTransformerImp.java
@@ -26,6 +26,7 @@ import com.growingio.android.sdk.track.events.VisitorAttributesEvent;
 import com.growingio.android.sdk.track.events.base.BaseEvent;
 import com.growingio.android.sdk.track.log.Logger;
 import com.growingio.android.sdk.track.providers.EventBuilderProvider;
+import com.growingio.android.sdk.track.utils.ConstantPool;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -49,6 +50,8 @@ public class HybridTransformerImp implements HybridTransformer {
                 return transformViewElementEventBuilder(type, eventJson);
             } else if (TrackEventType.CUSTOM.equals(type)) {
                 HybridCustomEvent.Builder builder = new HybridCustomEvent.Builder();
+                int customType = eventJson.optInt("customEventType", ConstantPool.CUSTOM_TYPE_SYSTEM);
+                builder.setCustomEventType(customType);
                 EventBuilderProvider.parseFrom(builder, eventJson);
                 return builder;
             } else if (TrackEventType.LOGIN_USER_ATTRIBUTES.equals(type)) {

--- a/growingio-hybrid/src/main/java/com/growingio/android/hybrid/SuperWebView.java
+++ b/growingio-hybrid/src/main/java/com/growingio/android/hybrid/SuperWebView.java
@@ -33,8 +33,6 @@ public abstract class SuperWebView<T extends View> {
         return mRealWebView;
     }
 
-    private boolean hasAddJavaScript = false;
-
     public void getLocationOnScreen(int[] outLocation) {
         getRealWebView().getLocationOnScreen(outLocation);
     }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
@@ -159,9 +159,9 @@ public class Tracker {
         trackerContext.getEventBuilderProvider().clearGeneralProps();
     }
 
-    public void clearGeneralProps(String... keys){
+    public void removeGeneralProps(String... keys){
         if (!isInited) return;
-        trackerContext.getEventBuilderProvider().clearGeneralProps(keys);
+        trackerContext.getEventBuilderProvider().removeGeneralProps(keys);
     }
 
     private void setConversionVariables(Map<String, String> variables) {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
@@ -151,17 +151,23 @@ public class Tracker {
 
     public void setGeneralProps(Map<String, String> variables) {
         if (!isInited || variables == null || variables.isEmpty()) return;
-        trackerContext.getEventBuilderProvider().setGeneralProps(variables);
+        TrackMainThread.trackMain().postActionToTrackMain(() ->
+                trackerContext.getEventBuilderProvider().setGeneralProps(variables)
+        );
     }
 
-    public void clearGeneralProps(){
+    public void clearGeneralProps() {
         if (!isInited) return;
-        trackerContext.getEventBuilderProvider().clearGeneralProps();
+        TrackMainThread.trackMain().postActionToTrackMain(() ->
+                trackerContext.getEventBuilderProvider().clearGeneralProps()
+        );
     }
 
-    public void removeGeneralProps(String... keys){
+    public void removeGeneralProps(String... keys) {
         if (!isInited) return;
-        trackerContext.getEventBuilderProvider().removeGeneralProps(keys);
+        TrackMainThread.trackMain().postActionToTrackMain(() ->
+                trackerContext.getEventBuilderProvider().removeGeneralProps(keys)
+        );
     }
 
     private void setConversionVariables(Map<String, String> variables) {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
@@ -149,6 +149,21 @@ public class Tracker {
         TrackEventGenerator.generateCustomEvent(eventName, attributes);
     }
 
+    public void setGeneralProps(Map<String, String> variables) {
+        if (!isInited || variables == null || variables.isEmpty()) return;
+        trackerContext.getEventBuilderProvider().setGeneralProps(variables);
+    }
+
+    public void clearGeneralProps(){
+        if (!isInited) return;
+        trackerContext.getEventBuilderProvider().clearGeneralProps();
+    }
+
+    public void clearGeneralProps(String... keys){
+        if (!isInited) return;
+        trackerContext.getEventBuilderProvider().clearGeneralProps(keys);
+    }
+
     private void setConversionVariables(Map<String, String> variables) {
         if (!isInited) return;
         if (variables == null || variables.isEmpty()) {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/TrackerContext.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/TrackerContext.java
@@ -22,6 +22,7 @@ import com.growingio.android.sdk.track.modelloader.TrackerRegistry;
 import com.growingio.android.sdk.track.providers.ActivityStateProvider;
 import com.growingio.android.sdk.track.providers.ConfigurationProvider;
 import com.growingio.android.sdk.track.providers.DeviceInfoProvider;
+import com.growingio.android.sdk.track.providers.EventBuilderProvider;
 import com.growingio.android.sdk.track.providers.TimingEventProvider;
 import com.growingio.android.sdk.track.providers.TrackerLifecycleProvider;
 import com.growingio.android.sdk.track.providers.UserInfoProvider;
@@ -93,6 +94,10 @@ public class TrackerContext extends ContextWrapper {
 
     public TimingEventProvider getTimingEventProvider() {
         return getProvider(TimingEventProvider.class);
+    }
+
+    public EventBuilderProvider getEventBuilderProvider() {
+        return getProvider(EventBuilderProvider.class);
     }
 
     private final TrackerRegistry registry;

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/TrackMainThread.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/TrackMainThread.java
@@ -65,7 +65,7 @@ public final class TrackMainThread {
     public void setupWithContext(TrackerContext context) {
         this.context = context.getBaseContext();
         this.coreConfiguration = context.getConfigurationProvider().core();
-        this.eventBuilderProvider = context.getProvider(EventBuilderProvider.class);
+        this.eventBuilderProvider = context.getEventBuilderProvider();
         this.persistentDataProvider = context.getProvider(PersistentDataProvider.class);
         this.sessionProvider = context.getProvider(SessionProvider.class);
         this.activityStateProvider = context.getActivityStateProvider();

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/AttributesBuilder.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/AttributesBuilder.java
@@ -164,6 +164,15 @@ public class AttributesBuilder {
         }
     }
 
+    public void clear() {
+        attributes.clear();
+    }
+
+    public AttributesBuilder removeAttribute(String key) {
+        attributes.remove(key);
+        return this;
+    }
+
     public Map<String, String> build() {
         if (attributes == null || attributes.isEmpty()) {
             return null;

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/AttributesBuilder.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/AttributesBuilder.java
@@ -168,6 +168,10 @@ public class AttributesBuilder {
         attributes.clear();
     }
 
+    public int size() {
+        return attributes.size();
+    }
+
     public AttributesBuilder removeAttribute(String key) {
         attributes.remove(key);
         return this;

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/CustomEvent.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/CustomEvent.java
@@ -61,7 +61,7 @@ public class CustomEvent extends BaseAttributesEvent {
 
         public Builder setGeneralProps(Map<String, String> generalProps) {
             if (customEventType == ConstantPool.CUSTOM_TYPE_USER) {
-                if (generalProps != null && generalProps.size() > 0) {
+                if (generalProps != null && !generalProps.isEmpty()) {
                     Map<String, String> attributes = getAttributes();
                     if (attributes == null) attributes = new HashMap<>();
                     for (String key : generalProps.keySet()) {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/CustomEvent.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/CustomEvent.java
@@ -61,7 +61,7 @@ public class CustomEvent extends BaseAttributesEvent {
 
         public Builder setGeneralProps(Map<String, String> generalProps) {
             if (customEventType == ConstantPool.CUSTOM_TYPE_USER) {
-                if (generalProps.size() > 0) {
+                if (generalProps != null && generalProps.size() > 0) {
                     Map<String, String> attributes = getAttributes();
                     if (attributes == null) attributes = new HashMap<>();
                     for (String key : generalProps.keySet()) {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/CustomEvent.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/CustomEvent.java
@@ -16,7 +16,11 @@
 package com.growingio.android.sdk.track.events;
 
 import com.growingio.android.sdk.track.events.base.BaseAttributesEvent;
+import com.growingio.android.sdk.track.utils.ConstantPool;
 import com.growingio.sdk.annotation.json.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @JsonSerializer
 public class CustomEvent extends BaseAttributesEvent {
@@ -35,6 +39,7 @@ public class CustomEvent extends BaseAttributesEvent {
 
     public static class Builder extends BaseAttributesEvent.Builder<CustomEvent> {
         private String eventName;
+        private int customEventType = ConstantPool.CUSTOM_TYPE_SYSTEM;
 
         public Builder() {
             super(TrackEventType.CUSTOM);
@@ -47,6 +52,27 @@ public class CustomEvent extends BaseAttributesEvent {
 
         public String getEventName() {
             return eventName;
+        }
+
+        public Builder setCustomEventType(int customEventType) {
+            this.customEventType = customEventType;
+            return this;
+        }
+
+        public Builder setGeneralProps(Map<String, String> generalProps) {
+            if (customEventType == ConstantPool.CUSTOM_TYPE_USER) {
+                if (generalProps.size() > 0) {
+                    Map<String, String> attributes = getAttributes();
+                    if (attributes == null) attributes = new HashMap<>();
+                    for (String key : generalProps.keySet()) {
+                        if (attributes.containsKey(key)) continue;
+                        String value = generalProps.get(key);
+                        attributes.put(key, value);
+                    }
+                    setAttributes(attributes);
+                }
+            }
+            return this;
         }
 
         @Override

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/TrackEventGenerator.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/events/TrackEventGenerator.java
@@ -16,6 +16,7 @@
 package com.growingio.android.sdk.track.events;
 
 import com.growingio.android.sdk.track.TrackMainThread;
+import com.growingio.android.sdk.track.utils.ConstantPool;
 
 import java.util.Map;
 
@@ -32,6 +33,7 @@ public class TrackEventGenerator {
     public static void generateCustomEvent(String name, Map<String, String> attributes) {
         TrackMainThread.trackMain().postEventToTrackMain(
                 new CustomEvent.Builder()
+                        .setCustomEventType(ConstantPool.CUSTOM_TYPE_USER)
                         .setEventName(name)
                         .setAttributes(attributes)
         );

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventBuilderProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventBuilderProvider.java
@@ -92,6 +92,7 @@ public class EventBuilderProvider implements TrackerLifecycleProvider {
             for (String key : properties.keySet()) {
                 String value = properties.get(key);
                 generalProps.addAttribute(key, value);
+                Logger.d(TAG, "add general props:[" + key + "-" + value + "]");
             }
         }
     }
@@ -103,6 +104,7 @@ public class EventBuilderProvider implements TrackerLifecycleProvider {
     public void clearGeneralProps(String... keys) {
         for (String key : keys) {
             generalProps.removeAttribute(key);
+            Logger.d(TAG, "remove general props of: " + key);
         }
     }
 

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventBuilderProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventBuilderProvider.java
@@ -18,11 +18,13 @@ package com.growingio.android.sdk.track.providers;
 import android.text.TextUtils;
 
 import com.growingio.android.sdk.TrackerContext;
+import com.growingio.android.sdk.track.events.AttributesBuilder;
 import com.growingio.android.sdk.track.events.CustomEvent;
 import com.growingio.android.sdk.track.events.EventBuildInterceptor;
 import com.growingio.android.sdk.track.events.EventFilterInterceptor;
 import com.growingio.android.sdk.track.events.PageEvent;
 import com.growingio.android.sdk.track.events.PageLevelCustomEvent;
+import com.growingio.android.sdk.track.events.TrackEventType;
 import com.growingio.android.sdk.track.events.ViewElementEvent;
 import com.growingio.android.sdk.track.events.base.BaseEvent;
 import com.growingio.android.sdk.track.events.helper.DefaultEventFilterInterceptor;
@@ -55,6 +57,8 @@ public class EventBuilderProvider implements TrackerLifecycleProvider {
     private ConfigurationProvider configurationProvider;
     private TrackerContext context;
 
+    private final AttributesBuilder generalProps = new AttributesBuilder();
+
     EventBuilderProvider() {
     }
 
@@ -83,17 +87,47 @@ public class EventBuilderProvider implements TrackerLifecycleProvider {
         serializableFactory.parseFrom(builder, jsonObject);
     }
 
+    public void setGeneralProps(Map<String, String> properties) {
+        if (properties != null && properties.keySet() != null) {
+            for (String key : properties.keySet()) {
+                String value = properties.get(key);
+                generalProps.addAttribute(key, value);
+            }
+        }
+    }
+
+    public void clearGeneralProps() {
+        generalProps.clear();
+    }
+
+    public void clearGeneralProps(String... keys) {
+        for (String key : keys) {
+            generalProps.removeAttribute(key);
+        }
+    }
+
     @TrackThread
     public BaseEvent onGenerateGEvent(BaseEvent.BaseBuilder<?> gEvent) {
         dispatchEventWillBuild(gEvent);
 
         if (!filterEvent(gEvent)) return null;
+
+        addGeneralPropsToEvent(gEvent);
         gEvent.readPropertyInTrackThread(context);
 
         BaseEvent event = gEvent.build();
         dispatchEventDidBuild(event);
 
         return event;
+    }
+
+    private void addGeneralPropsToEvent(BaseEvent.BaseBuilder<?> gEvent) {
+        if (gEvent.getEventType().equals(TrackEventType.CUSTOM)) {
+            if (gEvent instanceof CustomEvent.Builder) {
+                CustomEvent.Builder customEventBuilder = (CustomEvent.Builder) gEvent;
+                customEventBuilder.setGeneralProps(generalProps.build());
+            }
+        }
     }
 
     public void removeEventBuildInterceptor(EventBuildInterceptor interceptor) {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventBuilderProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventBuilderProvider.java
@@ -101,7 +101,7 @@ public class EventBuilderProvider implements TrackerLifecycleProvider {
         generalProps.clear();
     }
 
-    public void clearGeneralProps(String... keys) {
+    public void removeGeneralProps(String... keys) {
         for (String key : keys) {
             generalProps.removeAttribute(key);
             Logger.d(TAG, "remove general props of: " + key);

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/ConstantPool.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/ConstantPool.java
@@ -21,4 +21,7 @@ public class ConstantPool {
 
     public static final String UNKNOWN = "UNKNOWN";
     public static final String ANDROID = "Android";
+
+    public static final int CUSTOM_TYPE_SYSTEM = 0;
+    public static final int CUSTOM_TYPE_USER = 1;
 }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/view/ViewTreeStatusListener.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/view/ViewTreeStatusListener.java
@@ -47,7 +47,7 @@ public abstract class ViewTreeStatusListener implements IActivityLifecycle, OnVi
     @Override
     public void setup(TrackerContext context) {
         activityStateProvider = context.getActivityStateProvider();
-        eventBuilderProvider = context.getProvider(EventBuilderProvider.class);
+        eventBuilderProvider = context.getEventBuilderProvider();
     }
 
     @Override

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/TrackerTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/TrackerTest.java
@@ -42,7 +42,7 @@ public class TrackerTest {
     public void initTest() {
         try {
             Tracker nullTracker = new Tracker(null);
-        }catch (Exception e){
+        } catch (Exception e) {
             assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
     }
@@ -64,6 +64,10 @@ public class TrackerTest {
         tracker.setLocation(0d, 1d);
         tracker.cleanLocation();
         tracker.onActivityNewIntent(null, null);
+
+        tracker.setGeneralProps(valueMap);
+        tracker.clearGeneralProps("user");
+        tracker.clearGeneralProps();
 
         WebView webView = new WebView(application);
         tracker.bridgeWebView(webView);

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/TrackerTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/TrackerTest.java
@@ -66,7 +66,7 @@ public class TrackerTest {
         tracker.onActivityNewIntent(null, null);
 
         tracker.setGeneralProps(valueMap);
-        tracker.clearGeneralProps("user");
+        tracker.removeGeneralProps("user");
         tracker.clearGeneralProps();
 
         WebView webView = new WebView(application);

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/providers/EventBuilderProviderFilterTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/providers/EventBuilderProviderFilterTest.java
@@ -31,6 +31,7 @@ import com.growingio.android.sdk.track.events.base.BaseEvent;
 import com.growingio.android.sdk.track.events.base.BaseField;
 import com.growingio.android.sdk.track.events.helper.DefaultEventFilterInterceptor;
 import com.growingio.android.sdk.track.middleware.GEvent;
+import com.growingio.android.sdk.track.utils.ConstantPool;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -38,6 +39,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @Config(manifest = Config.NONE)
@@ -90,7 +92,7 @@ public class EventBuilderProviderFilterTest {
 
     @Test
     public void filterEventType() {
-        EventBuilderProvider eventBuilderProvider = context.getProvider(EventBuilderProvider.class);
+        EventBuilderProvider eventBuilderProvider = context.getEventBuilderProvider();
 
         eventBuilderProvider.addEventBuildInterceptor(new EventBuildInterceptor() {
             @Override
@@ -112,7 +114,7 @@ public class EventBuilderProviderFilterTest {
 
     @Test
     public void filterEventName() {
-        EventBuilderProvider eventBuilderProvider = context.getProvider(EventBuilderProvider.class);
+        EventBuilderProvider eventBuilderProvider = context.getEventBuilderProvider();
         eventBuilderProvider.addEventBuildInterceptor(new EventBuildInterceptor() {
             @Override
             public void eventWillBuild(BaseEvent.BaseBuilder<?> eventBuilder) {
@@ -132,7 +134,7 @@ public class EventBuilderProviderFilterTest {
 
     @Test
     public void filterEventField() {
-        EventBuilderProvider eventBuilderProvider = context.getProvider(EventBuilderProvider.class);
+        EventBuilderProvider eventBuilderProvider = context.getEventBuilderProvider();
         eventBuilderProvider.addEventBuildInterceptor(new EventBuildInterceptor() {
             @Override
             public void eventWillBuild(BaseEvent.BaseBuilder<?> eventBuilder) {
@@ -149,6 +151,32 @@ public class EventBuilderProviderFilterTest {
             }
         });
         eventBuilderProvider.onGenerateGEvent(new CustomEvent.Builder().setEventName("cpacm"));
+    }
+
+    @Test
+    public void generalPropsTest(){
+        EventBuilderProvider eventBuilderProvider = context.getEventBuilderProvider();
+        Map<String,String> generalProps = new HashMap<>();
+        generalProps.put("project","sdk");
+        generalProps.put("feature","test");
+        eventBuilderProvider.setGeneralProps(generalProps);
+        eventBuilderProvider.addEventBuildInterceptor(new EventBuildInterceptor() {
+            @Override
+            public void eventWillBuild(BaseEvent.BaseBuilder<?> eventBuilder) {
+            }
+
+            @Override
+            public void eventDidBuild(GEvent event) {
+                if (event instanceof CustomEvent) {
+                    CustomEvent customEvent = (CustomEvent) event;
+                    Truth.assertThat(customEvent.getAttributes()).isNotNull();
+                    Truth.assertThat(customEvent.getAttributes().get("feature")).isEqualTo("test");
+                    Truth.assertThat(customEvent.getAttributes().get("project")).isEqualTo("sdk");
+                    Truth.assertThat(customEvent.getEventName()).isEqualTo("cpacm");
+                }
+            }
+        });
+        eventBuilderProvider.onGenerateGEvent(new CustomEvent.Builder().setCustomEventType(ConstantPool.CUSTOM_TYPE_USER).setEventName("cpacm"));
     }
 
 }

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/timer/TimingEventProviderTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/timer/TimingEventProviderTest.java
@@ -58,8 +58,8 @@ public class TimingEventProviderTest {
 
     @Test
     public void backgroundThenForeground() throws InterruptedException {
-        TimingEventProvider timingEventProvider = context.getProvider(TimingEventProvider.class);
-        EventBuilderProvider eventBuilderProvider = context.getProvider(EventBuilderProvider.class);
+        TimingEventProvider timingEventProvider = context.getTimingEventProvider();
+        EventBuilderProvider eventBuilderProvider = context.getEventBuilderProvider();
         ActivityController<RobolectricActivity> activityController = Robolectric.buildActivity(RobolectricActivity.class);
         activityController.create().start().resume();
 
@@ -110,8 +110,8 @@ public class TimingEventProviderTest {
     @Test
     public void pauseThenResume() throws InterruptedException {
 
-        TimingEventProvider timingEventProvider = context.getProvider(TimingEventProvider.class);
-        EventBuilderProvider eventBuilderProvider = context.getProvider(EventBuilderProvider.class);
+        TimingEventProvider timingEventProvider = context.getTimingEventProvider();
+        EventBuilderProvider eventBuilderProvider = context.getEventBuilderProvider();
         final class TimerResult {
             public String eventName;
             public float elapsedTime;

--- a/growingio-webservice/debugger/src/main/java/com/growingio/android/debugger/DebuggerEventProvider.java
+++ b/growingio-webservice/debugger/src/main/java/com/growingio/android/debugger/DebuggerEventProvider.java
@@ -55,7 +55,7 @@ public class DebuggerEventProvider implements EventBuildInterceptor, TrackerLife
     @Override
     public void setup(TrackerContext context) {
         configurationProvider = context.getConfigurationProvider();
-        eventBuilderProvider = context.getProvider(EventBuilderProvider.class);
+        eventBuilderProvider = context.getEventBuilderProvider();
         // before debugger start, cache events.
         eventBuilderProvider.addEventBuildInterceptor(this);
     }


### PR DESCRIPTION
## PR 内容
为 SDK 添加通用属性接口：`setGeneralProps(Map<String,String>)`
设置通用属性后，所有调用 `trackCustomEvent` 发送的数据都会携带通用属性到事件属性中。


## 测试步骤

测试通用属性接口可用，包括：
`setGeneralProps(Map<String,String>)`
`clearGeneralProps()`
`removeGeneralProps(String...)`

## 影响范围
SDK 基础功能。


## 是否属于重要变动？

- [ ] 是
- [x] 否


## 其他信息


