### PR TITLE
feat:为网络请求添加超时配置

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,10 +11,10 @@ buildscript {
         ]
 
         releaseConfiguration = [
-                releaseVersion    : "3.5.2",
-                releaseVersionCode: 30502,
+                releaseVersion    : "3.5.3",
+                releaseVersionCode: 30503,
 
-                pluginVersion     : "3.5.0-SNAPSHOT"
+                pluginVersion     : "3.5.2"
         ]
 
         versions = [

--- a/build.gradle
+++ b/build.gradle
@@ -145,6 +145,7 @@ buildscript {
         mavenCentral()
         maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
         google()
+        gradlePluginPortal()
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {

--- a/demos/demo/build.gradle
+++ b/demos/demo/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         google()
         mavenLocal()
         mavenCentral()
+        gradlePluginPortal()
         maven {url "https://s01.oss.sonatype.org/content/repositories/snapshots/"}
     }
     dependencies {

--- a/growingio-advert/src/main/java/com/growingio/android/advert/AdvertLibraryGioModule.java
+++ b/growingio-advert/src/main/java/com/growingio/android/advert/AdvertLibraryGioModule.java
@@ -28,7 +28,7 @@ import com.growingio.sdk.annotation.GIOLibraryModule;
  *
  * @author cpacm 2022/08/02
  */
-@GIOLibraryModule
+@GIOLibraryModule(config = AdvertConfig.class)
 public class AdvertLibraryGioModule extends LibraryGioModule {
     @Override
     public void registerComponents(Context context, TrackerRegistry registry) {

--- a/growingio-annotation/compiler/src/main/java/com/growingio/sdk/annotation/compiler/ConfigurationGenerator.kt
+++ b/growingio-annotation/compiler/src/main/java/com/growingio/sdk/annotation/compiler/ConfigurationGenerator.kt
@@ -281,7 +281,7 @@ internal class ConfigurationGenerator(
         val enclosingClass = method.enclosingElement
         require(!enclosingClass.modifiers.contains(Modifier.ABSTRACT)) { "Cannot transform method on abstract class $enclosingClass" }
         var modifiers = method.modifiers
-        if (modifiers.contains(Modifier.PRIVATE) || modifiers.contains(Modifier.PROTECTED)) {
+        if (!modifiers.contains(Modifier.PUBLIC)) {
             processUtils.debugLog("cannot transform method with modifiers: $modifiers")
             return null
         }

--- a/growingio-apm/src/main/java/com/growingio/android/apm/ApmLibraryGioModule.java
+++ b/growingio-apm/src/main/java/com/growingio/android/apm/ApmLibraryGioModule.java
@@ -28,7 +28,7 @@ import com.growingio.sdk.annotation.GIOLibraryModule;
  *
  * @author cpacm 4/28/21
  */
-@GIOLibraryModule
+@GIOLibraryModule(config = ApmConfig.class)
 public class ApmLibraryGioModule extends LibraryGioModule {
     @Override
     public void registerComponents(Context context, TrackerRegistry registry) {

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/inject/UtilsInjector.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/inject/UtilsInjector.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2023 Beijing Yishu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.growingio.android.sdk.autotrack.inject;
+
+import com.growingio.android.sdk.track.log.Logger;
+
+/**
+ * <p>
+ *
+ * @author cpacm 2023/8/22
+ */
+public class UtilsInjector {
+    private UtilsInjector() {
+    }
+    public static void log(String tag, String message, Object... args) {
+        Logger.d(tag, message, args);
+    }
+}

--- a/growingio-network/okhttp3/src/main/java/com/growingio/android/okhttp3/OkHttpConfig.java
+++ b/growingio-network/okhttp3/src/main/java/com/growingio/android/okhttp3/OkHttpConfig.java
@@ -37,7 +37,7 @@ public class OkHttpConfig implements Configurable {
      *
      * <p>Default: connectTimeout + readTimeout + writeTimeout = 30s
      */
-    public OkHttpConfig setOkHttpCallTimeout(long timeout, TimeUnit unit) {
+    public OkHttpConfig setRequestTimeout(long timeout, TimeUnit unit) {
         callTimeout = checkDuration("timeout", timeout, unit);
         return this;
     }
@@ -51,7 +51,7 @@ public class OkHttpConfig implements Configurable {
      *
      * <p>Default: connectTimeout + readTimeout + writeTimeout = 30s
      */
-    public OkHttpConfig setOkHttpTimeout(long connectTimeout, long readTimeout, long writeTimeout, TimeUnit unit) {
+    public OkHttpConfig setRequestDetailTimeout(long connectTimeout, long readTimeout, long writeTimeout, TimeUnit unit) {
         this.callTimeout = 0;
         this.connectTimeout = checkDuration("callTimeout", connectTimeout, unit);
         this.readTimeout = checkDuration("readTimeout", readTimeout, unit);

--- a/growingio-network/okhttp3/src/main/java/com/growingio/android/okhttp3/OkHttpConfig.java
+++ b/growingio-network/okhttp3/src/main/java/com/growingio/android/okhttp3/OkHttpConfig.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (C) 2023 Beijing Yishu Technology Co., Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.growingio.android.okhttp3;
+
+import com.growingio.android.sdk.Configurable;
+
+import java.util.concurrent.TimeUnit;
+
+public class OkHttpConfig implements Configurable {
+    private static final int DEFAULT_OKHTTP_TIMEOUT = 10;
+    private int callTimeout = 0;
+    private int connectTimeout = checkDuration("connectTimeout", DEFAULT_OKHTTP_TIMEOUT, TimeUnit.SECONDS);
+    private int readTimeout = checkDuration("readTimeout", DEFAULT_OKHTTP_TIMEOUT, TimeUnit.SECONDS);
+    private int writeTimeout = checkDuration("writeTimeout", DEFAULT_OKHTTP_TIMEOUT, TimeUnit.SECONDS);
+
+    /**
+     * Sets the default timeout for complete calls. A value of 0 means no timeout, otherwise values
+     * must be between 1 and {@link Integer#MAX_VALUE} when converted to milliseconds.
+     *
+     * <p>The call timeout spans the entire call: resolving DNS, connecting, writing the request
+     * body, server processing, and reading the response body. If the call requires redirects or
+     * retries all must complete within one timeout period.
+     *
+     * <p>Default: connectTimeout + readTimeout + writeTimeout = 30s
+     */
+    public OkHttpConfig setOkHttpCallTimeout(long timeout, TimeUnit unit) {
+        callTimeout = checkDuration("timeout", timeout, unit);
+        return this;
+    }
+
+    /**
+     * Sets the default timeout for complete calls.
+     *
+     * <p>The call timeout spans the entire call: resolving DNS, connecting, writing the request
+     * body, server processing, and reading the response body. If the call requires redirects or
+     * retries all must complete within one timeout period.
+     *
+     * <p>Default: connectTimeout + readTimeout + writeTimeout = 30s
+     */
+    public OkHttpConfig setOkHttpTimeout(long connectTimeout, long readTimeout, long writeTimeout, TimeUnit unit) {
+        this.callTimeout = 0;
+        this.connectTimeout = checkDuration("callTimeout", connectTimeout, unit);
+        this.readTimeout = checkDuration("readTimeout", readTimeout, unit);
+        this.writeTimeout = checkDuration("writeTimeout", writeTimeout, unit);
+        return this;
+    }
+
+    private static int checkDuration(String name, long duration, TimeUnit unit) {
+        if (duration < 0) throw new IllegalArgumentException(name + " < 0");
+        if (unit == null) throw new NullPointerException("unit == null");
+        long millis = unit.toMillis(duration);
+        if (millis > Integer.MAX_VALUE) throw new IllegalArgumentException(name + " too large.");
+        if (millis == 0 && duration > 0) throw new IllegalArgumentException(name + " too small.");
+        return (int) millis;
+    }
+
+    public int getHttpCallTimeout() {
+        return callTimeout;
+    }
+
+    int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    int getReadTimeout() {
+        return readTimeout;
+    }
+
+    int getWriteTimeout() {
+        return writeTimeout;
+    }
+}

--- a/growingio-network/okhttp3/src/main/java/com/growingio/android/okhttp3/OkhttpLibraryGioModule.java
+++ b/growingio-network/okhttp3/src/main/java/com/growingio/android/okhttp3/OkhttpLibraryGioModule.java
@@ -29,10 +29,14 @@ import com.growingio.sdk.annotation.GIOLibraryModule;
  *
  * @author cpacm 4/28/21
  */
-@GIOLibraryModule
+@GIOLibraryModule(config = OkHttpConfig.class)
 public class OkhttpLibraryGioModule extends LibraryGioModule {
     @Override
     public void registerComponents(Context context, TrackerRegistry registry) {
-        registry.register(EventUrl.class, EventResponse.class, new OkHttpDataLoader.Factory());
+        OkHttpConfig config = getConfiguration(OkHttpConfig.class);
+        if (config == null) {
+            config = new OkHttpConfig();
+        }
+        registry.register(EventUrl.class, EventResponse.class, new OkHttpDataLoader.Factory(config));
     }
 }

--- a/growingio-network/urlconnection/src/main/java/com/growingio/android/urlconnection/UrlConnectionConfig.java
+++ b/growingio-network/urlconnection/src/main/java/com/growingio/android/urlconnection/UrlConnectionConfig.java
@@ -22,8 +22,9 @@ import java.util.concurrent.TimeUnit;
 
 public class UrlConnectionConfig implements Configurable {
 
-    private int connectTimeout = 5_000;
-    private int readTimeout = 5_000;
+    public static final int DEFAULT_URL_CONNECTION_TIMEOUT = 15_000;
+    private int connectTimeout = DEFAULT_URL_CONNECTION_TIMEOUT;
+    private int readTimeout = DEFAULT_URL_CONNECTION_TIMEOUT;
 
     public UrlConnectionConfig setConnectTimeout(long connectTimeout, TimeUnit unit) {
         this.connectTimeout = checkDuration("connectTimeout", connectTimeout, unit);
@@ -44,7 +45,7 @@ public class UrlConnectionConfig implements Configurable {
     }
 
     private static int checkDuration(String name, long duration, TimeUnit unit) {
-        if (duration < 0) throw new IllegalArgumentException(name + " < 0");
+        if (duration <= 0) throw new IllegalArgumentException(name + " <= 0");
         if (unit == null) throw new NullPointerException("unit == null");
         long millis = unit.toMillis(duration);
         if (millis > Integer.MAX_VALUE) throw new IllegalArgumentException(name + " too large.");

--- a/growingio-network/urlconnection/src/main/java/com/growingio/android/urlconnection/UrlConnectionConfig.java
+++ b/growingio-network/urlconnection/src/main/java/com/growingio/android/urlconnection/UrlConnectionConfig.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (C) 2023 Beijing Yishu Technology Co., Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.growingio.android.urlconnection;
+
+import com.growingio.android.sdk.Configurable;
+
+import java.util.concurrent.TimeUnit;
+
+public class UrlConnectionConfig implements Configurable {
+
+    private int connectTimeout = 5_000;
+    private int readTimeout = 5_000;
+
+    public UrlConnectionConfig setConnectTimeout(long connectTimeout, TimeUnit unit) {
+        this.connectTimeout = checkDuration("connectTimeout", connectTimeout, unit);
+        return this;
+    }
+
+    public UrlConnectionConfig setReadTimeout(long readTimeout, TimeUnit unit) {
+        this.readTimeout = checkDuration("readTimeout", readTimeout, unit);
+        return this;
+    }
+
+    int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    int getReadTimeout() {
+        return readTimeout;
+    }
+
+    private static int checkDuration(String name, long duration, TimeUnit unit) {
+        if (duration < 0) throw new IllegalArgumentException(name + " < 0");
+        if (unit == null) throw new NullPointerException("unit == null");
+        long millis = unit.toMillis(duration);
+        if (millis > Integer.MAX_VALUE) throw new IllegalArgumentException(name + " too large.");
+        if (millis == 0 && duration > 0) throw new IllegalArgumentException(name + " too small.");
+        return (int) millis;
+    }
+}

--- a/growingio-network/urlconnection/src/main/java/com/growingio/android/urlconnection/UrlConnectionFetcher.java
+++ b/growingio-network/urlconnection/src/main/java/com/growingio/android/urlconnection/UrlConnectionFetcher.java
@@ -16,6 +16,8 @@
 
 package com.growingio.android.urlconnection;
 
+import static com.growingio.android.urlconnection.UrlConnectionConfig.DEFAULT_URL_CONNECTION_TIMEOUT;
+
 import android.text.TextUtils;
 
 import com.growingio.android.sdk.track.middleware.http.EventResponse;
@@ -42,7 +44,6 @@ public class UrlConnectionFetcher implements HttpDataFetcher<EventResponse> {
     private static final String TAG = "UrlConnectionFetcher";
 
     private static final int MAXIMUM_REDIRECTS = 2;
-    private static final int TIME_OUT = 5000;
     private static final String REDIRECT_HEADER_FIELD = "Location";
     private static final int INVALID_STATUS_CODE = -1;
     private static final HttpUrlConnectionFactory DEFAULT_CONNECTION_FACTORY =
@@ -65,8 +66,8 @@ public class UrlConnectionFetcher implements HttpDataFetcher<EventResponse> {
             connectTimeout = config.getConnectTimeout();
             readTimeout = config.getReadTimeout();
         } else {
-            connectTimeout = TIME_OUT;
-            readTimeout = TIME_OUT;
+            connectTimeout = DEFAULT_URL_CONNECTION_TIMEOUT;
+            readTimeout = DEFAULT_URL_CONNECTION_TIMEOUT;
         }
     }
 

--- a/growingio-network/urlconnection/src/main/java/com/growingio/android/urlconnection/UrlConnectionFetcher.java
+++ b/growingio-network/urlconnection/src/main/java/com/growingio/android/urlconnection/UrlConnectionFetcher.java
@@ -22,6 +22,7 @@ import com.growingio.android.sdk.track.middleware.http.EventResponse;
 import com.growingio.android.sdk.track.middleware.http.EventUrl;
 import com.growingio.android.sdk.track.log.Logger;
 import com.growingio.android.sdk.track.middleware.http.HttpDataFetcher;
+import com.growingio.android.sdk.track.providers.ConfigurationProvider;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -54,8 +55,19 @@ public class UrlConnectionFetcher implements HttpDataFetcher<EventResponse> {
     private InputStream stream;
     private volatile boolean isCancelled;
 
+    private final int connectTimeout;
+    private final int readTimeout;
+
     public UrlConnectionFetcher(EventUrl eventUrl) {
         this.eventUrl = eventUrl;
+        UrlConnectionConfig config = ConfigurationProvider.get().getConfiguration(UrlConnectionConfig.class);
+        if (config != null) {
+            connectTimeout = config.getConnectTimeout();
+            readTimeout = config.getReadTimeout();
+        } else {
+            connectTimeout = TIME_OUT;
+            readTimeout = TIME_OUT;
+        }
     }
 
     @Override
@@ -150,8 +162,8 @@ public class UrlConnectionFetcher implements HttpDataFetcher<EventResponse> {
                 urlConnection.addRequestProperty(headerEntry.getKey(), headerEntry.getValue());
             }
             urlConnection.setRequestMethod("POST");
-            urlConnection.setConnectTimeout(TIME_OUT);
-            urlConnection.setReadTimeout(TIME_OUT);
+            urlConnection.setConnectTimeout(connectTimeout);
+            urlConnection.setReadTimeout(readTimeout);
             urlConnection.setUseCaches(false);
             urlConnection.setDoInput(true);
             if (data != null) {

--- a/growingio-network/urlconnection/src/main/java/com/growingio/android/urlconnection/UrlConnectionGioModule.java
+++ b/growingio-network/urlconnection/src/main/java/com/growingio/android/urlconnection/UrlConnectionGioModule.java
@@ -29,7 +29,7 @@ import com.growingio.sdk.annotation.GIOLibraryModule;
  *
  * @author cpacm 4/28/21
  */
-@GIOLibraryModule
+@GIOLibraryModule(config = UrlConnectionConfig.class)
 public class UrlConnectionGioModule extends LibraryGioModule {
     @Override
     public void registerComponents(Context context, TrackerRegistry registry) {

--- a/growingio-network/volley/src/main/java/com/growingio/android/volley/VolleyConfig.java
+++ b/growingio-network/volley/src/main/java/com/growingio/android/volley/VolleyConfig.java
@@ -22,9 +22,11 @@ import java.util.concurrent.TimeUnit;
 
 public class VolleyConfig implements Configurable {
 
-    private int timeout = 5_000;
+    public static final int DEFAULT_VOLLEY_TIMEOUT = 30_000;
 
-    public VolleyConfig setVolleyTimeout(long timeout, TimeUnit unit) {
+    private int timeout = DEFAULT_VOLLEY_TIMEOUT;
+
+    public VolleyConfig setRequestTimeout(long timeout, TimeUnit unit) {
         this.timeout = checkDuration("timeout", timeout, unit);
         return this;
     }
@@ -34,7 +36,7 @@ public class VolleyConfig implements Configurable {
     }
 
     private static int checkDuration(String name, long duration, TimeUnit unit) {
-        if (duration < 0) throw new IllegalArgumentException(name + " < 0");
+        if (duration <= 0) throw new IllegalArgumentException(name + " <= 0");
         if (unit == null) throw new NullPointerException("unit == null");
         long millis = unit.toMillis(duration);
         if (millis > Integer.MAX_VALUE) throw new IllegalArgumentException(name + " too large.");

--- a/growingio-network/volley/src/main/java/com/growingio/android/volley/VolleyConfig.java
+++ b/growingio-network/volley/src/main/java/com/growingio/android/volley/VolleyConfig.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (C) 2023 Beijing Yishu Technology Co., Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.growingio.android.volley;
+
+import com.growingio.android.sdk.Configurable;
+
+import java.util.concurrent.TimeUnit;
+
+public class VolleyConfig implements Configurable {
+
+    private int timeout = 5_000;
+
+    public VolleyConfig setVolleyTimeout(long timeout, TimeUnit unit) {
+        this.timeout = checkDuration("timeout", timeout, unit);
+        return this;
+    }
+
+    int getVolleyTimeout() {
+        return timeout;
+    }
+
+    private static int checkDuration(String name, long duration, TimeUnit unit) {
+        if (duration < 0) throw new IllegalArgumentException(name + " < 0");
+        if (unit == null) throw new NullPointerException("unit == null");
+        long millis = unit.toMillis(duration);
+        if (millis > Integer.MAX_VALUE) throw new IllegalArgumentException(name + " too large.");
+        if (millis == 0 && duration > 0) throw new IllegalArgumentException(name + " too small.");
+        return (int) millis;
+    }
+}

--- a/growingio-network/volley/src/main/java/com/growingio/android/volley/VolleyDataFetcher.java
+++ b/growingio-network/volley/src/main/java/com/growingio/android/volley/VolleyDataFetcher.java
@@ -69,7 +69,7 @@ public class VolleyDataFetcher implements HttpDataFetcher<EventResponse> {
         if (config != null) {
             timeout = config.getVolleyTimeout();
         } else {
-            timeout = 5_000;
+            timeout = VolleyConfig.DEFAULT_VOLLEY_TIMEOUT;
         }
     }
 

--- a/growingio-network/volley/src/main/java/com/growingio/android/volley/VolleyDataFetcher.java
+++ b/growingio-network/volley/src/main/java/com/growingio/android/volley/VolleyDataFetcher.java
@@ -30,6 +30,7 @@ import com.growingio.android.sdk.track.middleware.http.EventResponse;
 import com.growingio.android.sdk.track.middleware.http.EventUrl;
 import com.growingio.android.sdk.track.log.Logger;
 import com.growingio.android.sdk.track.middleware.http.HttpDataFetcher;
+import com.growingio.android.sdk.track.providers.ConfigurationProvider;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
@@ -53,6 +54,8 @@ public class VolleyDataFetcher implements HttpDataFetcher<EventResponse> {
     private final EventUrl url;
     private volatile com.android.volley.Request<byte[]> request;
 
+    private final long timeout;
+
     public VolleyDataFetcher(RequestQueue requestQueue, EventUrl eventUrl) {
         this(requestQueue, eventUrl, DEFAULT_REQUEST_FACTORY);
     }
@@ -62,6 +65,12 @@ public class VolleyDataFetcher implements HttpDataFetcher<EventResponse> {
         this.requestQueue = requestQueue;
         this.url = url;
         this.requestFactory = requestFactory;
+        VolleyConfig config = ConfigurationProvider.get().getConfiguration(VolleyConfig.class);
+        if (config != null) {
+            timeout = config.getVolleyTimeout();
+        } else {
+            timeout = 5_000;
+        }
     }
 
 
@@ -84,7 +93,7 @@ public class VolleyDataFetcher implements HttpDataFetcher<EventResponse> {
         request = requestFactory.create(url.toUrl(), url.getHeaders(), url.getMediaType(), url.getRequestBody(), future, future);
         requestQueue.add(request);
         try {
-            return future.get(5L, TimeUnit.SECONDS);
+            return future.get(timeout, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Logger.e(TAG, e, "executeData interrupted");
             Thread.currentThread().interrupt();

--- a/growingio-network/volley/src/main/java/com/growingio/android/volley/VolleyLibraryGioModule.java
+++ b/growingio-network/volley/src/main/java/com/growingio/android/volley/VolleyLibraryGioModule.java
@@ -29,7 +29,7 @@ import com.growingio.sdk.annotation.GIOLibraryModule;
  *
  * @author cpacm 4/28/21
  */
-@GIOLibraryModule
+@GIOLibraryModule(config = VolleyConfig.class)
 public class VolleyLibraryGioModule extends LibraryGioModule {
     @Override
     public void registerComponents(Context context, TrackerRegistry registry) {


### PR DESCRIPTION
## PR 内容

分别为网络请求添加超时配置，包括Okhttp，UrlConnection和Volley.

Android由于多个Http请求库，所以为每个库添加了设置请求超时的方法。
默认的是OkHttp，接口为`setRequestTimeout(long timeout, TimeUnit unit) `和 `setRequestDetailTimeout(long connectTimeout, long readTimeout, long writeTimeout, TimeUnit unit)`。默认值统一采用okHttp的默认值，10+10+10 = 30s。

URLConnection 默认时间为java的请求时间为 15+15=30s。

Volley 默认为30s.

设置超时时间下限为0，上限为Max.

配置项编译后可以直接通过 `AutotrackConfiguration` 调用。

## 测试步骤

测试超时机制。


## 影响范围

<!-- 请描述你的PR能造成的影响范围. -->


## 是否属于重要变动？

- [ ] 是
- [x] 否


## 其他信息


