### PR TITLE
fix: fragment tag 存在随机赋值的问题

### DIFF
--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/AutotrackConfig.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/AutotrackConfig.java
@@ -21,7 +21,7 @@ public class AutotrackConfig implements Configurable {
     private float mImpressionScale = 0;
     private boolean mDowngrade = false;
 
-    private boolean supportFragmentTag = false;
+    private boolean enableFragmentTag = false;
     private final AutotrackOptions mAutotrackOptions = new AutotrackOptions();
 
     public AutotrackConfig setImpressionScale(float scale) {
@@ -52,13 +52,13 @@ public class AutotrackConfig implements Configurable {
         return mAutotrackOptions;
     }
 
-    public AutotrackConfig setSupportFragmentTag(boolean support) {
-        this.supportFragmentTag = support;
+    public AutotrackConfig enableFragmentTag(boolean enable) {
+        this.enableFragmentTag = enable;
         return this;
     }
 
-    public boolean isSupportFragmentTag() {
-        return supportFragmentTag;
+    public boolean isEnableFragmentTag() {
+        return enableFragmentTag;
     }
 
     /**

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/AutotrackConfig.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/AutotrackConfig.java
@@ -52,17 +52,13 @@ public class AutotrackConfig implements Configurable {
         return mAutotrackOptions;
     }
 
-    public AutotrackConfig setFragmentTagSupport(boolean support) {
+    public AutotrackConfig setSupportFragmentTag(boolean support) {
         this.supportFragmentTag = support;
         return this;
     }
 
     public boolean isSupportFragmentTag() {
         return supportFragmentTag;
-    }
-
-    public void setSupportFragmentTag(boolean supportFragmentTag) {
-        this.supportFragmentTag = supportFragmentTag;
     }
 
     /**

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/AutotrackConfig.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/AutotrackConfig.java
@@ -20,6 +20,8 @@ import com.growingio.android.sdk.Configurable;
 public class AutotrackConfig implements Configurable {
     private float mImpressionScale = 0;
     private boolean mDowngrade = false;
+
+    private boolean supportFragmentTag = false;
     private final AutotrackOptions mAutotrackOptions = new AutotrackOptions();
 
     public AutotrackConfig setImpressionScale(float scale) {
@@ -48,6 +50,19 @@ public class AutotrackConfig implements Configurable {
 
     public AutotrackOptions getAutotrackOptions() {
         return mAutotrackOptions;
+    }
+
+    public AutotrackConfig setFragmentTagSupport(boolean support) {
+        this.supportFragmentTag = support;
+        return this;
+    }
+
+    public boolean isSupportFragmentTag() {
+        return supportFragmentTag;
+    }
+
+    public void setSupportFragmentTag(boolean supportFragmentTag) {
+        this.supportFragmentTag = supportFragmentTag;
     }
 
     /**

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/FragmentPage.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/FragmentPage.java
@@ -53,11 +53,14 @@ public class FragmentPage extends Page<SuperFragment<?>> {
 
     @Override
     public String getTag() {
-        String tag = getCarrier().getTag();
-        if (!TextUtils.isEmpty(tag)) {
-            return transformSwitcherTag(tag);
+        if (autotrackConfig.isSupportFragmentTag()) {
+            String tag = getCarrier().getTag();
+            if (!TextUtils.isEmpty(tag)) {
+                return transformSwitcherTag(tag);
+            }
+            return getCarrier().getResourceEntryName(getCarrier().getId());
         }
-        return getCarrier().getResourceEntryName(getCarrier().getId());
+        return null;
     }
 
     /**

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/FragmentPage.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/FragmentPage.java
@@ -53,14 +53,13 @@ public class FragmentPage extends Page<SuperFragment<?>> {
 
     @Override
     public String getTag() {
-        if (autotrackConfig.isSupportFragmentTag()) {
+        if (autotrackConfig.isEnableFragmentTag()) {
             String tag = getCarrier().getTag();
             if (!TextUtils.isEmpty(tag)) {
                 return transformSwitcherTag(tag);
             }
-            return getCarrier().getResourceEntryName(getCarrier().getId());
         }
-        return null;
+        return getCarrier().getResourceEntryName(getCarrier().getId());
     }
 
     /**

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/SuperFragment.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/SuperFragment.java
@@ -134,15 +134,12 @@ public abstract class SuperFragment<T> {
 
         @Override
         public String getResourceEntryName(int id) {
-            if (getRealFragment() == null) return "SystemFragment";
+            if (getRealFragment() == null || id == View.NO_ID) return null;
             try {
-                if (id == -1) {
-                    id = getRealFragment().getId();
-                }
                 return getRealFragment().getResources().getResourceEntryName(id);
             } catch (Resources.NotFoundException ignored) {
             }
-            return "SystemFragment";
+            return null;
         }
 
         @Nullable
@@ -208,15 +205,12 @@ public abstract class SuperFragment<T> {
 
         @Override
         public String getResourceEntryName(int id) {
-            if (getRealFragment() == null) return "SystemFragment";
+            if (getRealFragment() == null || id == View.NO_ID) return null;
             try {
-                if (id == -1) {
-                    id = getRealFragment().getId();
-                }
                 return getRealFragment().getResources().getResourceEntryName(id);
             } catch (Resources.NotFoundException ignored) {
             }
-            return "SystemFragment";
+            return null;
         }
 
         @Nullable

--- a/growingio-autotracker-core/src/test/java/com/growingio/android/sdk/autotrack/page/PageTest.java
+++ b/growingio-autotracker-core/src/test/java/com/growingio/android/sdk/autotrack/page/PageTest.java
@@ -59,7 +59,7 @@ public class PageTest {
     @Before
     public void setup() {
         Map<Class<? extends Configurable>, Configurable> map = new HashMap<>();
-        map.put(AutotrackConfig.class, new AutotrackConfig().setSupportFragmentTag(true));
+        map.put(AutotrackConfig.class, new AutotrackConfig().enableFragmentTag(true));
         TrackerLifecycleProviderFactory.create().createConfigurationProviderWithConfig(new CoreConfiguration("PageTest", "growingio://impression"), map);
 
         Autotracker autotracker = new Autotracker(application);

--- a/growingio-autotracker-core/src/test/java/com/growingio/android/sdk/autotrack/page/PageTest.java
+++ b/growingio-autotracker-core/src/test/java/com/growingio/android/sdk/autotrack/page/PageTest.java
@@ -59,7 +59,7 @@ public class PageTest {
     @Before
     public void setup() {
         Map<Class<? extends Configurable>, Configurable> map = new HashMap<>();
-        map.put(AutotrackConfig.class, new AutotrackConfig());
+        map.put(AutotrackConfig.class, new AutotrackConfig().setSupportFragmentTag(true));
         TrackerLifecycleProviderFactory.create().createConfigurationProviderWithConfig(new CoreConfiguration("PageTest", "growingio://impression"), map);
 
         Autotracker autotracker = new Autotracker(application);


### PR DESCRIPTION
## PR 内容

在使用高版本 Navigation 库（2.7.3）时，Navigation库会对所有的导航 Fragment 赋予一个 UUID 生成的随机TAG。为了保证无埋点路径的准确，取消无埋点路径xcontent中对tag的支持，现在默认取 Fragment 的id为xcontent路径。

新增无埋点的配置，若客户需要tag支持，可在配置中打开 `enableFragmentTag(true)`。


## 测试步骤
测试无埋点Fragment的路径是否正确。

## 影响范围
无埋点 Fragment 路径。


## 是否属于重要变动？

- [x] 是
- [ ] 否


## 其他信息


