### PR TITLE
feat: data validity period

### DIFF
--- a/growingio-data/database/src/main/java/com/growingio/android/database/DatabaseDataFetcher.java
+++ b/growingio-data/database/src/main/java/com/growingio/android/database/DatabaseDataFetcher.java
@@ -51,7 +51,6 @@ public class DatabaseDataFetcher implements DataFetcher<EventDbResult> {
         }
     }
 
-
     private EventDbResult executeDatabase(EventDatabase database) throws IllegalArgumentException {
         EventDbResult dbResult = new EventDbResult();
         if (database.getDbOp() == EventDatabase.DATABASE_OP_INSERT) {
@@ -61,7 +60,8 @@ public class DatabaseDataFetcher implements DataFetcher<EventDbResult> {
             dbResult.setSuccess(count == database.getEvents().size());
             return dbResult;
         } else if (database.getDbOp() == EventDatabase.DATABASE_OP_OUTDATED) {
-            int sum = dataManager.removeOverdueEvents();
+            int day = database.getLimit();
+            int sum = dataManager.removeOverdueEvents(day);
             dbResult.setSum(sum);
             dbResult.setSuccess(sum >= 0);
             return dbResult;

--- a/growingio-data/database/src/main/java/com/growingio/android/database/EventDataManager.java
+++ b/growingio-data/database/src/main/java/com/growingio/android/database/EventDataManager.java
@@ -45,7 +45,7 @@ import static com.growingio.android.database.EventDataTable.TABLE_EVENTS;
 public class EventDataManager {
     private static final String TAG = "EventDataManager";
 
-    private static final long EVENT_VALID_PERIOD_MILLS = 7L * 24 * 60 * 60_000;
+    private static final long EVENT_VALID_PERIOD_MILLS = 24 * 60 * 60_000L;
     private static final double EVENT_DATA_MAX_SIZE = 2 * 1000 * 1024; // 2M
 
     private final TrackerContext context;
@@ -60,7 +60,8 @@ public class EventDataManager {
         deprecatedEventSQLite.migrateEvents();
 
         // when sdk start,removeOverdueEvents
-        removeOverdueEvents();
+        int day = context.getConfigurationProvider().core().getDataValidityPeriod();
+        removeOverdueEvents(day);
     }
 
     private EventByteArray formatData(EventFormatData data) {
@@ -112,13 +113,15 @@ public class EventDataManager {
         return null;
     }
 
-    int removeOverdueEvents() {
+    int removeOverdueEvents(int day) {
         if (ignoreOperations) {
             return -1;
         }
         try {
             long current = System.currentTimeMillis();
-            long sevenDayAgo = current - EVENT_VALID_PERIOD_MILLS;
+            if (day > 30) day = 30;
+            if (day < 3) day = 3;
+            long sevenDayAgo = current - day * EVENT_VALID_PERIOD_MILLS;
 
             ContentResolver contentResolver = context.getContentResolver();
             Uri uri = getContentUri();

--- a/growingio-data/database/src/test/java/com/growingio/android/database/DbTest.java
+++ b/growingio-data/database/src/test/java/com/growingio/android/database/DbTest.java
@@ -142,7 +142,7 @@ public class DbTest {
     public void contentProviderTest() {
         trackerContext.getRegistry().register(EventFormatData.class, EventByteArray.class, new JsonDataLoader.Factory());
         controller.create(providerInfo).get();
-        sqLite.removeOverdueEvents();
+        sqLite.removeOverdueEvents(7);
         CustomEvent customEvent = new CustomEvent.Builder()
                 .setEventName("contentProvider")
                 .build();

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/CoreConfiguration.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/CoreConfiguration.java
@@ -42,6 +42,7 @@ public class CoreConfiguration implements Configurable {
     private boolean mImeiEnabled = false;
     private boolean mAndroidIdEnabled = false;
 
+    private int mDataValidityPeriod = 7;
     private boolean requestPreflight = true;
 
 
@@ -212,6 +213,21 @@ public class CoreConfiguration implements Configurable {
      */
     public CoreConfiguration setRequestPreflight(boolean requestPreflight) {
         this.requestPreflight = requestPreflight;
+        return this;
+    }
+
+    public int getDataValidityPeriod() {
+        return mDataValidityPeriod;
+    }
+
+    /**
+     * Sets the cache data validity period. From 3 days to 30 days.
+     * <p> Default: 7 days.
+     *
+     * @param dataValidityPeriod data validity period, in days. for example, 7 means that the cache data is valid for 7 days.
+     */
+    public CoreConfiguration setDataValidityPeriod(int dataValidityPeriod) {
+        this.mDataValidityPeriod = dataValidityPeriod;
         return this;
     }
 }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/middleware/EventDatabase.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/middleware/EventDatabase.java
@@ -39,7 +39,6 @@ public class EventDatabase {
     private long lastId;
     private String eventType;
 
-
     public int getDbOp() {
         return dbOp;
     }
@@ -83,6 +82,14 @@ public class EventDatabase {
     public static EventDatabase outDated() {
         EventDatabase ed = new EventDatabase();
         ed.dbOp = DATABASE_OP_OUTDATED;
+        ed.limit = 7;
+        return ed;
+    }
+
+    public static EventDatabase outDated(int day) {
+        EventDatabase ed = new EventDatabase();
+        ed.dbOp = DATABASE_OP_OUTDATED;
+        ed.limit = day;
         return ed;
     }
 


### PR DESCRIPTION
## PR 内容

SDK 添加配置项由于配置数据缓存时间 `setDataValidityPeriod(int days)`.天数不大于30，不小于3.



## 测试步骤

数据缓存


## 影响范围

数据库事件缓存。


## 是否属于重要变动？

- [ ] 是
- [x] 否


## 其他信息


