### PR TITLE
fix: ContentProviderClient NPE.

### DIFF
--- a/growingio-data/database/src/main/java/com/growingio/android/database/EventDataManager.java
+++ b/growingio-data/database/src/main/java/com/growingio/android/database/EventDataManager.java
@@ -181,7 +181,11 @@ public class EventDataManager {
             Logger.e(TAG, t, t.getMessage());
         } finally {
             if (client != null) {
-                client.release();
+                try {
+                    client.release();
+                } catch (java.lang.NullPointerException e) {
+                    // does nothing, Binder connection already null
+                }
             }
         }
     }
@@ -225,7 +229,11 @@ public class EventDataManager {
             Logger.e(TAG, t, t.getMessage());
         } finally {
             if (client != null) {
-                client.release();
+                try {
+                    client.release();
+                } catch (java.lang.NullPointerException e) {
+                    // does nothing, Binder connection already null
+                }
             }
         }
     }


### PR DESCRIPTION
## PR 内容

调用ContentProviderClient.release()时在某些机型上（比如oppo）会出现 IBinder 已经释放的情况导致出现空异常。


## 测试步骤

无，少数案例


## 影响范围

部分机型，个例


## 是否属于重要变动？

- [ ] 是
- [x] 否


## 其他信息


