### PR TITLE
feat: page leave

### DIFF
--- a/gio-sdk/autotracker-cdp/build.gradle
+++ b/gio-sdk/autotracker-cdp/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 	debugApi project(':growingio-autotracker-core')
 	debugApi project(':growingio-network:okhttp3')
 	debugApi project(':growingio-data:database')
-	debugApi project(':growingio-data:protobuf')
+	debugApi project(':growingio-data:json')
 	debugApi project(':growingio-webservice:circler')
 	debugApi project(':growingio-webservice:debugger')
 	debugApi project(':growingio-hybrid')

--- a/gio-sdk/autotracker-cdp/src/main/java/com/growingio/android/sdk/autotrack/CdpDowngradeProvider.java
+++ b/gio-sdk/autotracker-cdp/src/main/java/com/growingio/android/sdk/autotrack/CdpDowngradeProvider.java
@@ -38,6 +38,7 @@ public class CdpDowngradeProvider implements TrackerLifecycleProvider {
      */
     private void downgrade() {
         AutotrackConfig config = configurationProvider.getConfiguration(AutotrackConfig.class);
+        config.enablePageLeave(true);
         config.getAutotrackOptions().setFragmentPageEnabled(true);
         config.getAutotrackOptions().setActivityPageEnabled(true);
     }

--- a/gio-sdk/tracker-cdp/build.gradle
+++ b/gio-sdk/tracker-cdp/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 	debugApi project(':growingio-tracker-core')
 	debugApi project(':growingio-network:okhttp3')
 	debugApi project(':growingio-data:database')
-	debugApi project(':growingio-data:protobuf')
+	debugApi project(':growingio-data:json')
 	debugApi project(':growingio-webservice:debugger')
 
 	releaseApi libs.bundles.growingio.tracker.sdk

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/AutotrackConfig.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/AutotrackConfig.java
@@ -30,7 +30,7 @@ public class AutotrackConfig implements Configurable {
     private boolean autotrackEnabled = true;
     private int pageXmlRes = 0;
     private final List<PageRule> pageRules = new ArrayList<>();
-    private boolean enablePageLeave = false;
+    private boolean pageLeaveEnabled = false;
 
     public AutotrackConfig setImpressionScale(float scale) {
         if (scale < 0) {
@@ -139,13 +139,13 @@ public class AutotrackConfig implements Configurable {
         return enableFragmentTag;
     }
 
-    public AutotrackConfig enablePageLeave(boolean enable) {
-        this.enablePageLeave = enable;
+    public AutotrackConfig setPageLeaveEnabled(boolean enable) {
+        this.pageLeaveEnabled = enable;
         return this;
     }
 
-    public boolean isEnablePageLeave() {
-        return enablePageLeave;
+    public boolean isPageLeaveEnabled() {
+        return pageLeaveEnabled;
     }
 
     public List<PageRule> getPageRules() {

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/AutotrackConfig.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/AutotrackConfig.java
@@ -30,6 +30,7 @@ public class AutotrackConfig implements Configurable {
     private boolean autotrackEnabled = true;
     private int pageXmlRes = 0;
     private final List<PageRule> pageRules = new ArrayList<>();
+    private boolean enablePageLeave = false;
 
     public AutotrackConfig setImpressionScale(float scale) {
         if (scale < 0) {
@@ -136,6 +137,15 @@ public class AutotrackConfig implements Configurable {
 
     public boolean isEnableFragmentTag() {
         return enableFragmentTag;
+    }
+
+    public AutotrackConfig enablePageLeave(boolean enable) {
+        this.enablePageLeave = enable;
+        return this;
+    }
+
+    public boolean isEnablePageLeave() {
+        return enablePageLeave;
     }
 
     public List<PageRule> getPageRules() {

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/inject/FragmentInjector.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/inject/FragmentInjector.java
@@ -30,10 +30,17 @@ public class FragmentInjector {
         PageProvider.get().createOrResumePage(SuperFragment.make(fragment));
     }
 
+    public static void systemFragmentOnStop(android.app.Fragment fragment) {
+        Logger.d(TAG, "systemFragmentOnStop: fragment = " + fragment.getClass().getName());
+        PageProvider.get().fragmentOnStop(SuperFragment.make(fragment));
+    }
+
     public static void systemFragmentSetUserVisibleHint(android.app.Fragment fragment, boolean isVisibleToUser) {
         Logger.d(TAG, "systemFragmentSetUserVisibleHint: fragment = " + fragment.getClass().getName() + ", isVisibleToUser = " + isVisibleToUser);
         if (isVisibleToUser) {
             PageProvider.get().createOrResumePage(SuperFragment.make(fragment));
+        } else {
+            PageProvider.get().fragmentOnHiddenChanged(SuperFragment.make(fragment), true);
         }
     }
 
@@ -52,6 +59,11 @@ public class FragmentInjector {
         PageProvider.get().createOrResumePage(SuperFragment.makeX(fragment));
     }
 
+    public static void androidxFragmentOnStop(androidx.fragment.app.Fragment fragment) {
+        Logger.d(TAG, "androidxFragmentOnStop: fragment = " + fragment.getClass().getName());
+        PageProvider.get().fragmentOnStop(SuperFragment.makeX(fragment));
+    }
+
     /**
      * 新版本的AndroidX Fragment setUserVisibleHint 将通过 FragmentTransaction setMaxLifecycle 来控制生命周期实现
      */
@@ -60,6 +72,8 @@ public class FragmentInjector {
         Logger.d(TAG, "androidxFragmentSetUserVisibleHint: fragment = " + fragment.getClass().getName() + ", isVisibleToUser = " + isVisibleToUser);
         if (isVisibleToUser) {
             PageProvider.get().createOrResumePage(SuperFragment.makeX(fragment));
+        } else {
+            PageProvider.get().fragmentOnHiddenChanged(SuperFragment.makeX(fragment), true);
         }
     }
 

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/inject/FragmentV4Injector.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/inject/FragmentV4Injector.java
@@ -30,10 +30,17 @@ public class FragmentV4Injector {
         PageProvider.get().createOrResumePage(SuperFragment.makeSupport(fragment));
     }
 
+    public static void v4FragmentOnStop(android.support.v4.app.Fragment fragment) {
+        Logger.d(TAG, "v4FragmentOnStop: fragment = " + fragment.getClass().getName());
+        PageProvider.get().fragmentOnStop(SuperFragment.makeSupport(fragment));
+    }
+
     public static void v4FragmentSetUserVisibleHint(android.support.v4.app.Fragment fragment, boolean isVisibleToUser) {
         Logger.d(TAG, "v4FragmentSetUserVisibleHint: fragment = " + fragment.getClass().getName() + ", isVisibleToUser = " + isVisibleToUser);
         if (isVisibleToUser) {
             PageProvider.get().createOrResumePage(SuperFragment.makeSupport(fragment));
+        } else {
+            PageProvider.get().fragmentOnHiddenChanged(SuperFragment.makeSupport(fragment), true);
         }
     }
 

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/Page.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/Page.java
@@ -39,6 +39,7 @@ public abstract class Page<T> {
     private final T mCarrier;
     private Page<?> mParent;
     private long mShowTimestamp;
+    private boolean mIsLeave = false;
     private boolean mIsAutotrack = false; //是否标记为可发送
 
     private boolean mIsIgnored = false;
@@ -62,6 +63,7 @@ public abstract class Page<T> {
     }
 
     public void refreshShowTimestamp() {
+        mIsLeave = false;
         mShowTimestamp = System.currentTimeMillis();
     }
 
@@ -83,6 +85,14 @@ public abstract class Page<T> {
 
     public long getShowTimestamp() {
         return mShowTimestamp;
+    }
+
+    public void setIsLeave(boolean isLeave) {
+        this.mIsLeave = isLeave;
+    }
+
+    public boolean isLeave() {
+        return mIsLeave;
     }
 
     public Map<String, String> getAttributes() {
@@ -297,4 +307,5 @@ public abstract class Page<T> {
             return false;
         }
     }
+
 }

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/PageConfig.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/PageConfig.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 class PageConfig {
     private boolean enableFragmentTag = false;
+    private boolean enablePageLeave = false;
     private List<PageRule> pageRuleList;
     private boolean isActivityPageEnabled = true;
     private boolean isFragmentPageEnabled = true;
@@ -27,11 +28,15 @@ class PageConfig {
 
     private boolean autotrack = true;
 
-    public PageConfig(List<PageRule> pageRuleList, boolean isActivityPageEnabled, boolean isFragmentPageEnabled, boolean enableFragmentTag, boolean isDowngrade,boolean autotrack) {
+    public PageConfig(List<PageRule> pageRuleList, boolean isActivityPageEnabled, boolean isFragmentPageEnabled,
+                      boolean enableFragmentTag, boolean enablePageLeave,
+                      boolean isDowngrade,
+                      boolean autotrack) {
         this.pageRuleList = pageRuleList;
         this.isActivityPageEnabled = isActivityPageEnabled;
         this.isFragmentPageEnabled = isFragmentPageEnabled;
         this.enableFragmentTag = enableFragmentTag;
+        this.enablePageLeave = enablePageLeave;
         this.isDowngrade = isDowngrade;
         this.autotrack = autotrack;
     }
@@ -54,6 +59,10 @@ class PageConfig {
 
     public boolean isDowngrade() {
         return isDowngrade;
+    }
+
+    public boolean isPageLeaveEnabled() {
+        return enablePageLeave;
     }
 
     public boolean isAutotrack() {

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/PageLeave.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/PageLeave.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (C) 2025 Beijing Yishu Technology Co., Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.growingio.android.sdk.autotrack.page;
+
+import androidx.annotation.NonNull;
+
+import com.growingio.android.sdk.TrackerContext;
+import com.growingio.android.sdk.track.TrackMainThread;
+import com.growingio.android.sdk.track.events.AttributesBuilder;
+import com.growingio.android.sdk.track.events.CustomEvent;
+
+import java.util.Map;
+
+public class PageLeave implements Thread.UncaughtExceptionHandler {
+
+    static final String PAGE_LEAVE_EVENT_NAME = "$page_leave";
+    static final String PAGE_NAME = "$page_alias";
+    static final String PAGE_DURATION = "$page_duration";
+    static final String PAGE_PATH = "$page_path";
+
+    public static void buildPageLeaveEvent(Page<?> page) {
+        buildPageLeaveEvent(page, false);
+    }
+
+    public static void buildPageLeaveEvent(Page<?> page, boolean isSync) {
+        if (!page.isAutotrack() || page.isLeave()) return;
+
+        long duration = System.currentTimeMillis() - page.getShowTimestamp();
+        Map<String, String> attributes = new AttributesBuilder()
+                .addAttribute(PAGE_NAME, page.getName())
+                .addAttribute(PAGE_DURATION, duration)
+                .addAttribute(PAGE_PATH, page.pagePath())
+                .build();
+        CustomEvent.Builder builder = new CustomEvent.Builder()
+                .setEventName(PAGE_LEAVE_EVENT_NAME);
+        builder.setAttributes(attributes);
+        page.setIsLeave(true);
+        if (isSync) {
+            TrackMainThread.trackMain().sendEventSync(builder);
+        } else {
+            TrackMainThread.trackMain().postEventToTrackMain(builder);
+        }
+    }
+
+    private final Thread.UncaughtExceptionHandler lastExceptionHandler;
+    private final PageProvider pageProvider;
+
+    protected PageLeave(TrackerContext context) {
+        pageProvider = context.getProvider(PageProvider.class);
+        lastExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
+        Thread.setDefaultUncaughtExceptionHandler(this);
+    }
+
+    @Override
+    public void uncaughtException(@NonNull Thread t, @NonNull Throwable e) {
+        try {
+            pageProvider.sendAllPagesLeave();
+            if (lastExceptionHandler != null) {
+                lastExceptionHandler.uncaughtException(t, e);
+            }
+        } catch (Exception ignored) {
+        }
+
+    }
+}

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/PageProvider.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/PageProvider.java
@@ -492,6 +492,33 @@ public class PageProvider implements IActivityLifecycle, TrackerLifecycleProvide
         }
     }
 
+    @UiThread
+    public void fragmentOnStop(SuperFragment<?> fragment) {
+        if (!TrackerContext.initializedSuccessfully()) {
+            Logger.e(TAG, "Autotracker do not initialized successfully");
+            return;
+        }
+
+        if (fragment == null) {
+            Logger.w(TAG, "fragmentOnStop: this fragment can not make superFragment");
+            return;
+        }
+
+        Logger.d(TAG, "fragmentOnStop: fragment is " + fragment.getSimpleName());
+
+        if (pageConfig.isPageLeaveEnabled()) {
+            Activity activity = fragment.getActivity();
+            if (activity == null) return;
+            Page<?> page = ALL_PAGE_TREE.get(activity);
+            if (page != null) {
+                Page<?> fragmentPage = searchFragmentPage(fragment, page);
+                if (fragmentPage != null) {
+                    PageLeave.buildPageLeaveEvent(fragmentPage);
+                }
+            }
+        }
+    }
+
     private Page<?> removePageFromTree(SuperFragment<?> carrier, Page<?> page) {
         Iterator<Page<?>> iterator = page.getAllChildren().iterator();
         while (iterator.hasNext()) {

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/PageProvider.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/PageProvider.java
@@ -88,7 +88,7 @@ public class PageProvider implements IActivityLifecycle, TrackerLifecycleProvide
             boolean isActivityPageEnabled = autotrackConfig.getAutotrackOptions().isActivityPageEnabled();
             boolean isFragmentPageEnabled = autotrackConfig.getAutotrackOptions().isFragmentPageEnabled();
             boolean enableFragmentTag = autotrackConfig.isEnableFragmentTag();
-            boolean enablePageLeave = autotrackConfig.isEnablePageLeave();
+            boolean enablePageLeave = autotrackConfig.isPageLeaveEnabled();
             List<PageRule> pageRuleList = XmlParserUtil.loadPageRuleXml(context, autotrackConfig.getPageXmlRes());
             autotrackConfig.getPageRules().addAll(0, pageRuleList);
 


### PR DESCRIPTION
## PR 内容
1. 添加配置项 `enablePageLeave`：是否增加页面离开事件，事件为自定义事件，将包含页面名称，页面停留事件，页面路径属性。
2. 页面离开事件逻辑：Activity 为 onResume -> onStop 生命周期期间；Fragment 为 onResume(onShow)-> onStop(onHidden)
3. 页面无埋点不生效时，不产生页面离开事件。



## 测试步骤

请使用 SDK CDP 测试页面离开事件。


## 影响范围

<!-- 请描述你的PR能造成的影响范围. -->


## 是否属于重要变动？

- [ ] 是
- [x] 否


## 其他信息


