### PR TITLE
fix: tipview crash

### DIFF
--- a/growingio-webservice/circler/src/main/java/com/growingio/android/circler/ThreadSafeTipView.java
+++ b/growingio-webservice/circler/src/main/java/com/growingio/android/circler/ThreadSafeTipView.java
@@ -19,6 +19,7 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.res.Resources;
 
 import com.growingio.android.sdk.track.SDKConfig;
 import com.growingio.android.sdk.track.TrackMainThread;
@@ -51,7 +52,6 @@ public class ThreadSafeTipView {
         this.appVersion = appVersion;
         this.context = context;
         this.activityStateProvider = activityStateProvider;
-        runOnUiThread(this::initView);
     }
 
     public void enableShow() {

--- a/growingio-webservice/circler/src/main/java/com/growingio/android/circler/ThreadSafeTipView.java
+++ b/growingio-webservice/circler/src/main/java/com/growingio/android/circler/ThreadSafeTipView.java
@@ -19,7 +19,6 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.content.res.Resources;
 
 import com.growingio.android.sdk.track.SDKConfig;
 import com.growingio.android.sdk.track.TrackMainThread;

--- a/growingio-webservice/debugger/src/main/java/com/growingio/android/debugger/ThreadSafeTipView.java
+++ b/growingio-webservice/debugger/src/main/java/com/growingio/android/debugger/ThreadSafeTipView.java
@@ -51,7 +51,6 @@ public class ThreadSafeTipView {
         this.appVersion = appVersion;
         this.context = context;
         this.activityStateProvider = activityStateProvider;
-        runOnUiThread(this::initView);
     }
 
     public void enableShow() {


### PR DESCRIPTION
## PR 内容

在 minikin.so 的原生代码库中，由于小米等机型有更改系统字体的自定义设置，有概率导致在获取字体集合时出现问题。目前移除在SDK中的圈选和Debugger中的 TipView 初始化避免影响客户的C端用户。


## 测试步骤

1. 测试圈选和debugger功能不受影响；
2. 使用小米等能设置自定义字体的系统尝试复现；

## 影响范围

<!-- 请描述你的PR能造成的影响范围. -->


## 是否属于重要变动？

- [ ] 是
- [x] 否


## 其他信息


