### PR TITLE
feat: add setPageTitle api in autotracker

### DIFF
--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/Autotracker.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/Autotracker.java
@@ -270,6 +270,42 @@ public class Autotracker extends Tracker {
         setPageAttributes(page, attributes);
     }
 
+    public void setPageTitle(final Activity activity, final String title) {
+        if (!isInited) return;
+        if (activity == null || TextUtils.isEmpty(title)) {
+            Logger.e(TAG, "activity or title is NULL");
+            return;
+        }
+        TrackMainThread.trackMain().runOnUiThread(() -> PageProvider.get().setPageTitle(activity, title));
+    }
+
+    public void setPageTitle(final androidx.fragment.app.Fragment page, final String title) {
+        if (!isInited) return;
+        if (page == null || TextUtils.isEmpty(title)) {
+            Logger.e(TAG, "page or title is NULL");
+            return;
+        }
+        TrackMainThread.trackMain().runOnUiThread(() -> PageProvider.get().setPageTitle(SuperFragment.makeX(page), title));
+    }
+
+    public void setPageTitleSystem(final android.app.Fragment page, final String title) {
+        if (!isInited) return;
+        if (page == null || TextUtils.isEmpty(title)) {
+            Logger.e(TAG, "page or title is NULL");
+            return;
+        }
+        TrackMainThread.trackMain().runOnUiThread(() -> PageProvider.get().setPageTitle(SuperFragment.make(page), title));
+    }
+
+    public void setPageTitleSupport(final android.support.v4.app.Fragment page, final String title) {
+        if (!isInited) return;
+        if (page == null || TextUtils.isEmpty(title)) {
+            Logger.e(TAG, "page or title is NULL");
+            return;
+        }
+        TrackMainThread.trackMain().runOnUiThread(() -> PageProvider.get().setPageTitle(SuperFragment.makeSupport(page), title));
+    }
+
     public void trackViewImpression(View view, String impressionEventName) {
         if (!isInited) return;
         trackViewImpression(view, impressionEventName, null);

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/ActivityPage.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/ActivityPage.java
@@ -22,6 +22,7 @@ import android.view.View;
 
 public class ActivityPage extends Page<SuperActivity> {
 
+    private String customTitle;
     private PageConfig pageConfig;
 
     public ActivityPage(Activity carrier) {
@@ -79,11 +80,20 @@ public class ActivityPage extends Page<SuperActivity> {
 
     @Override
     public String getTitle() {
+        if (customTitle != null) {
+            return customTitle;
+        }
         Activity activity = getCarrier().getRealActivity();
         if (activity != null && !TextUtils.isEmpty(activity.getTitle())) {
             return activity.getTitle().toString();
         }
         return super.getTitle();
+    }
+
+    @Override
+    protected void setTitle(String title) {
+        this.customTitle = title;
+        super.setTitle(title);
     }
 
     @Override

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/PageProvider.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/PageProvider.java
@@ -533,6 +533,21 @@ public class PageProvider implements IActivityLifecycle, TrackerLifecycleProvide
         page.setAttributes(attributes);
     }
 
+    public void setPageTitle(Activity activity, String title) {
+        Page page = findOrCreateActivityPage(activity);
+        setPageTitle(page, title);
+    }
+
+    public void setPageTitle(SuperFragment<?> fragment, String title) {
+        Page<?> page = findOrCreateFragmentPage(fragment);
+        setPageTitle(page, title);
+    }
+
+    private void setPageTitle(Page<?> page, String title) {
+        if (page == null || title == null) return;
+        page.setTitle(title);
+    }
+
     public Page<?> findPage(View view) {
         Page<?> page = ViewAttributeUtil.getViewPage(view);
         if (page != null) {


### PR DESCRIPTION
## PR 内容

为无埋点添加新的接口：setPageTitle，用于手动设置页面的标题。


## 测试步骤

<!-- 请描述怎样操作才证明已经处理了问题. -->


## 影响范围

<!-- 请描述你的PR能造成的影响范围. -->


## 是否属于重要变动？

- [ ] 是
- [x] 否


## 其他信息


