### PR TITLE
feat: add flush api to force upload events

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,8 +31,8 @@ protobufPlugin = "0.9.5"
 protobuf = "4.31.1"
 
 # !!! SDK VERSION !!!
-growingio = "4.5.2"
-growingioCode = "40502"
+growingio = "4.5.3"
+growingioCode = "40503"
 growingioPlugin = "4.5.0"
 junit = "1.1.5"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ protobuf = "4.31.1"
 # !!! SDK VERSION !!!
 growingio = "4.5.3"
 growingioCode = "40503"
-growingioPlugin = "4.5.0"
+growingioPlugin = "4.5.2"
 junit = "1.1.5"
 
 [plugins]

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
@@ -37,6 +37,7 @@ import com.growingio.android.sdk.track.modelloader.ModelLoader;
 import com.growingio.android.sdk.track.middleware.hybrid.HybridBridge;
 import com.growingio.android.sdk.track.providers.ConfigurationProvider;
 import com.growingio.android.sdk.track.providers.DeepLinkProvider;
+import com.growingio.android.sdk.track.providers.EventSenderProvider;
 import com.growingio.android.sdk.track.providers.TrackerLifecycleProvider;
 import com.growingio.android.sdk.track.providers.TrackerLifecycleProviderFactory;
 import com.growingio.android.sdk.track.providers.SessionProvider;
@@ -157,7 +158,15 @@ public class Tracker {
 
     public void flushEvents() {
         if (!isInited) return;
-        TrackMainThread.trackMain().flushEvents();
+        TrackMainThread.trackMain().postActionToTrackMain(() -> {
+            ConfigurationProvider configurationProvider = trackerContext.getConfigurationProvider();
+            if (configurationProvider != null && configurationProvider.core()!=null  && configurationProvider.core().isDataCollectionEnabled()) {
+                EventSenderProvider eventSenderProvider = trackerContext.getProvider(EventSenderProvider.class);
+                if (eventSenderProvider != null) {
+                    eventSenderProvider.flush();
+                }
+            }
+        });
     }
 
     public void setDynamicGeneralPropsGenerator(DynamicGeneralPropsGenerator generator) {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
@@ -155,6 +155,11 @@ public class Tracker {
         TrackEventGenerator.generateCustomEvent(eventName, attributes);
     }
 
+    public void flushEvents() {
+        if (!isInited) return;
+        TrackMainThread.trackMain().flushEvents();
+    }
+
     public void setDynamicGeneralPropsGenerator(DynamicGeneralPropsGenerator generator) {
         if (!isInited) return;
         trackerContext.getEventBuilderProvider().setDynamicGeneralPropGenerator(generator);

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/Tracker.java
@@ -129,6 +129,7 @@ public class Tracker {
 
         // makeup activity lifecycle
         trackerContext.getActivityStateProvider().makeupActivityLifecycle();
+        trackerContext.getActivityStateProvider().listenNetworkChange();
 
     }
 
@@ -160,7 +161,7 @@ public class Tracker {
         if (!isInited) return;
         TrackMainThread.trackMain().postActionToTrackMain(() -> {
             ConfigurationProvider configurationProvider = trackerContext.getConfigurationProvider();
-            if (configurationProvider != null && configurationProvider.core()!=null  && configurationProvider.core().isDataCollectionEnabled()) {
+            if (configurationProvider != null && configurationProvider.core() != null && configurationProvider.core().isDataCollectionEnabled()) {
                 EventSenderProvider eventSenderProvider = trackerContext.getProvider(EventSenderProvider.class);
                 if (eventSenderProvider != null) {
                     eventSenderProvider.flush();

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/TrackMainThread.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/TrackMainThread.java
@@ -25,15 +25,14 @@ import com.growingio.android.sdk.CoreConfiguration;
 import com.growingio.android.sdk.TrackerContext;
 import com.growingio.android.sdk.track.log.CircularFifoQueue;
 import com.growingio.android.sdk.track.providers.ActivityStateProvider;
+import com.growingio.android.sdk.track.providers.EventSenderProvider;
 import com.growingio.android.sdk.track.providers.PersistentDataProvider;
 import com.growingio.android.sdk.track.events.base.BaseEvent;
 import com.growingio.android.sdk.track.listener.TrackThread;
 import com.growingio.android.sdk.track.log.Logger;
-import com.growingio.android.sdk.track.middleware.EventSender;
 import com.growingio.android.sdk.track.middleware.GEvent;
 import com.growingio.android.sdk.track.providers.EventBuilderProvider;
 import com.growingio.android.sdk.track.providers.SessionProvider;
-import com.growingio.android.sdk.track.middleware.EventHttpSender;
 
 /**
  * GrowingIO主线程
@@ -45,7 +44,7 @@ public final class TrackMainThread {
 
     private final Handler mainHandler;
     private final Handler uiHandler;
-    private EventSender eventSender;
+    private EventSenderProvider eventSenderProvider;
     private CoreConfiguration coreConfiguration;
     private EventBuilderProvider eventBuilderProvider;
     private PersistentDataProvider persistentDataProvider;
@@ -69,13 +68,7 @@ public final class TrackMainThread {
         this.persistentDataProvider = context.getProvider(PersistentDataProvider.class);
         this.sessionProvider = context.getProvider(SessionProvider.class);
         this.activityStateProvider = context.getActivityStateProvider();
-        int uploadInterval = coreConfiguration.isDebugEnabled() ? 0 : coreConfiguration.getDataUploadInterval();
-        eventSender = new EventSender(
-                this.context,
-                context.getRegistry(),
-                new EventHttpSender(context),
-                uploadInterval,
-                coreConfiguration.getCellularDataLimit());
+        this.eventSenderProvider = context.getProvider(EventSenderProvider.class);
     }
 
     public void shutdown() {
@@ -86,8 +79,7 @@ public final class TrackMainThread {
         this.persistentDataProvider = null;
         this.sessionProvider = null;
         this.activityStateProvider = null;
-        this.eventSender.shutdown();
-        this.eventSender = null;
+        this.eventSenderProvider = null;
     }
 
     private static class SingleInstance {
@@ -181,17 +173,7 @@ public final class TrackMainThread {
             // we should resend visitEvent when sessionId refreshed
             sessionProvider.generateVisit();
         }
-        if (eventSender != null) eventSender.sendEvent(event);
-    }
-
-    public void flushEvents() {
-        postActionToTrackMain(() -> {
-            if (coreConfiguration != null && coreConfiguration.isDataCollectionEnabled()) {
-                if (eventSender != null) {
-                    eventSender.flush();
-                }
-            }
-        });
+        if (eventSenderProvider != null) eventSenderProvider.sendEvent(event);
     }
 
     public synchronized Activity getForegroundActivity() {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/TrackMainThread.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/TrackMainThread.java
@@ -184,6 +184,16 @@ public final class TrackMainThread {
         if (eventSender != null) eventSender.sendEvent(event);
     }
 
+    public void flushEvents() {
+        postActionToTrackMain(() -> {
+            if (coreConfiguration != null && coreConfiguration.isDataCollectionEnabled()) {
+                if (eventSender != null) {
+                    eventSender.flush();
+                }
+            }
+        });
+    }
+
     public synchronized Activity getForegroundActivity() {
         if (activityStateProvider == null) return null;
         return activityStateProvider.getForegroundActivity();

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/middleware/EventSender.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/middleware/EventSender.java
@@ -74,6 +74,10 @@ public class EventSender {
         mSendHandler = new SendHandler(thread.getLooper(), dataUploadInterval * 1000L);
     }
 
+    public void flush(){
+        mSendHandler.flush();
+    }
+
     public void shutdown() {
         mProcessLock.release();
         mSendHandler.removeCallbacksAndMessages(null);
@@ -321,14 +325,18 @@ public class EventSender {
                 if (cacheEventNum >= EVENTS_BULK_SIZE && isNotBackoffState()) {
                     Logger.w(TAG, "cacheEventNum >= EVENTS_BULK_SIZE, merge events and send.");
                     cacheEventNum = 0;
-                    removeMessages(MSG_SEND_UNINSTANT_EVENTS);
-                    sendEmptyMessage(MSG_SEND_UNINSTANT_EVENTS);
+                    flush();
                 }
             } else {
-                removeMessages(MSG_SEND_UNINSTANT_EVENTS);
-                sendEmptyMessage(MSG_SEND_UNINSTANT_EVENTS);
+                flush();
             }
         }
+
+        private void flush(){
+            removeMessages(MSG_SEND_UNINSTANT_EVENTS);
+            sendEmptyMessage(MSG_SEND_UNINSTANT_EVENTS);
+        }
+
 
         @Override
         public void handleMessage(@NonNull Message msg) {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/ActivityStateProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/ActivityStateProvider.java
@@ -74,7 +74,9 @@ public class ActivityStateProvider extends ListenerContainer<IActivityLifecycle,
     public void setup(TrackerContext context) {
         configurationProvider = context.getConfigurationProvider();
         eventSenderProvider = context.getProvider(EventSenderProvider.class);
+    }
 
+    public void listenNetworkChange() {
         Application application = applicationWeakReference.get();
         if (application == null) {
             Logger.e(TAG, "Application is null, can't register network callback.");
@@ -238,7 +240,7 @@ public class ActivityStateProvider extends ListenerContainer<IActivityLifecycle,
             public void onAvailable(Network network) {
                 super.onAvailable(network);
                 Logger.i(TAG, "Network is available, flush messages.");
-                eventSenderProvider.flush();
+                if (eventSenderProvider != null) eventSenderProvider.flush();
             }
         };
 
@@ -256,7 +258,7 @@ public class ActivityStateProvider extends ListenerContainer<IActivityLifecycle,
                     NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
                     if (activeNetwork != null && activeNetwork.isConnected()) {
                         Logger.i(TAG, "Network is available, flush messages.");
-                        eventSenderProvider.flush();
+                        if (eventSenderProvider != null) eventSenderProvider.flush();
                     }
                 }
             }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/ActivityStateProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/ActivityStateProvider.java
@@ -15,11 +15,22 @@
  */
 package com.growingio.android.sdk.track.providers;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Application;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.net.NetworkInfo;
+import android.net.NetworkRequest;
+import android.os.Build;
 import android.os.Bundle;
+
+import androidx.annotation.RequiresApi;
 
 import com.growingio.android.sdk.TrackerContext;
 import com.growingio.android.sdk.track.listener.IActivityLifecycle;
@@ -37,8 +48,12 @@ public class ActivityStateProvider extends ListenerContainer<IActivityLifecycle,
     private WeakReference<Activity> mResumeActivity = new WeakReference<>(null);
     private WeakReference<Activity> mForegroundActivity = new WeakReference<>(null);
     private ConfigurationProvider configurationProvider;
+    private EventSenderProvider eventSenderProvider;
 
     private WeakReference<Application> applicationWeakReference;
+
+    private ConnectivityManager.NetworkCallback networkCallback;
+    private BroadcastReceiver networkReceiver;
 
     ActivityStateProvider(Context context) {
         if (context instanceof Application) {
@@ -58,6 +73,18 @@ public class ActivityStateProvider extends ListenerContainer<IActivityLifecycle,
     @Override
     public void setup(TrackerContext context) {
         configurationProvider = context.getConfigurationProvider();
+        eventSenderProvider = context.getProvider(EventSenderProvider.class);
+
+        Application application = applicationWeakReference.get();
+        if (application == null) {
+            Logger.e(TAG, "Application is null, can't register network callback.");
+            return;
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            registerNetworkCallback();
+        } else {
+            registerNetworkReceiver(application);
+        }
     }
 
     public void makeupActivityLifecycle() {
@@ -187,12 +214,75 @@ public class ActivityStateProvider extends ListenerContainer<IActivityLifecycle,
         listener.onActivityLifecycle(action);
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    @SuppressLint("WrongConstant")
+    private void registerNetworkCallback() {
+        Application application = applicationWeakReference.get();
+        if (application == null) {
+            Logger.e(TAG, "Application is null, can't register network callback.");
+            return;
+        }
+
+        ConnectivityManager connectivityManager = (ConnectivityManager) application.getSystemService(Context.CONNECTIVITY_SERVICE);
+        if (connectivityManager == null) {
+            Logger.e(TAG, "ConnectivityManager is null, can't register network callback.");
+            return;
+        }
+
+        NetworkRequest request = new NetworkRequest.Builder()
+                .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                .build();
+
+        this.networkCallback = new ConnectivityManager.NetworkCallback() {
+            @Override
+            public void onAvailable(Network network) {
+                super.onAvailable(network);
+                Logger.i(TAG, "Network is available, flush messages.");
+                eventSenderProvider.flush();
+            }
+        };
+
+        connectivityManager.registerNetworkCallback(request, networkCallback);
+    }
+
+    @SuppressWarnings("deprecation")
+    private void registerNetworkReceiver(Application application) {
+        networkReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                if (ConnectivityManager.CONNECTIVITY_ACTION.equals(intent.getAction())) {
+                    ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+                    if (cm == null) return;
+                    NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
+                    if (activeNetwork != null && activeNetwork.isConnected()) {
+                        Logger.i(TAG, "Network is available, flush messages.");
+                        eventSenderProvider.flush();
+                    }
+                }
+            }
+        };
+        application.registerReceiver(networkReceiver, new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
+    }
+
     @Override
     public void shutdown() {
         if (applicationWeakReference != null) {
             Application application = applicationWeakReference.get();
             if (application != null) {
                 application.unregisterActivityLifecycleCallbacks(this);
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    if (networkCallback != null) {
+                        ConnectivityManager connectivityManager = (ConnectivityManager) application.getSystemService(Context.CONNECTIVITY_SERVICE);
+                        if (connectivityManager != null) {
+                            connectivityManager.unregisterNetworkCallback(networkCallback);
+                        }
+                    }
+                } else {
+                    if (networkReceiver != null) {
+                        application.unregisterReceiver(networkReceiver);
+                    }
+                }
             }
         }
     }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventSenderProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventSenderProvider.java
@@ -1,19 +1,22 @@
 /*
- * Copyright (C) 2023 Beijing Yishu Technology Co., Ltd.
+ *  Copyright (C) 2026 Beijing Yishu Technology Co., Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
-package com.growingio.android.sdk.track.middleware;
+
+package com.growingio.android.sdk.track.providers;
+
+import static com.growingio.android.sdk.track.middleware.GEvent.SEND_POLICY_INSTANT;
 
 import android.annotation.SuppressLint;
 import android.app.ActivityManager;
@@ -27,69 +30,64 @@ import android.os.Message;
 
 import androidx.annotation.NonNull;
 
+import com.growingio.android.sdk.TrackerContext;
 import com.growingio.android.sdk.track.ipc.ProcessLock;
 import com.growingio.android.sdk.track.log.Logger;
+import com.growingio.android.sdk.track.middleware.EventDatabase;
+import com.growingio.android.sdk.track.middleware.EventDbResult;
+import com.growingio.android.sdk.track.middleware.EventHttpSender;
+import com.growingio.android.sdk.track.middleware.GEvent;
+import com.growingio.android.sdk.track.middleware.IEventNetSender;
+import com.growingio.android.sdk.track.middleware.SendResponse;
 import com.growingio.android.sdk.track.modelloader.ModelLoader;
-import com.growingio.android.sdk.track.modelloader.TrackerRegistry;
 import com.growingio.android.sdk.track.utils.NetworkUtil;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import static com.growingio.android.sdk.track.middleware.GEvent.SEND_POLICY_INSTANT;
+public class EventSenderProvider implements TrackerLifecycleProvider {
 
-/**
- * 事件发送者
- * - 多个进程公用同一个EventSender
- * - EventSender为单例模型，防止销毁后计数器归零
- */
-public class EventSender {
-    private static final String TAG = "EventSender";
+    private static final String TAG = "EventSenderProvider";
 
-    private final Context mContext;
-    private IEventNetSender mEventNetSender;
-    private final SharedPreferences mSharedPreferences;
-    private final SendHandler mSendHandler;
-    private final ProcessLock mProcessLock;
-    private final long mCellularDataLimit;
-    private final TrackerRegistry mRegistry;
+    private TrackerContext context;
+    private ConfigurationProvider configurationProvider;
+    private EventSenderProvider.SendHandler sendHandler;
+    private IEventNetSender eventNetSender;
+    private ProcessLock processLock;
+    private SharedPreferences sharedPreferences;
 
-    /**
-     * 事件发送管理类
-     *
-     * @param sender             网络发送的sender
-     * @param dataUploadInterval 发送事件的时间周期，单位 s
-     * @param cellularDataLimit  事件发送的移动网络的流量限制，单位 MB
-     */
-    @SuppressLint("WrongConstant")
-    public EventSender(Context context, TrackerRegistry registry, IEventNetSender sender, long dataUploadInterval, long cellularDataLimit) {
-        mContext = context.getApplicationContext();
-        mRegistry = registry;
-        mCellularDataLimit = cellularDataLimit * 1024L * 1024L;
-        mEventNetSender = sender;
-        mProcessLock = new ProcessLock(mContext, EventSender.class.getName());
-        mSharedPreferences = mContext.getSharedPreferences("growing3_sender", Context.MODE_PRIVATE);
-        HandlerThread thread = new HandlerThread(EventSender.class.getName());
+    @Override
+    @SuppressWarnings("WrongConstant")
+    public void setup(TrackerContext context) {
+        configurationProvider = context.getConfigurationProvider();
+        long dataUploadInterval = configurationProvider.core().getDataUploadInterval();
+
+        HandlerThread thread = new HandlerThread(EventSenderProvider.class.getName());
         thread.start();
-        mSendHandler = new SendHandler(thread.getLooper(), dataUploadInterval * 1000L);
+        sendHandler = new EventSenderProvider.SendHandler(thread.getLooper(), dataUploadInterval * 1000L);
+        eventNetSender = new EventHttpSender(context);
+        sharedPreferences = context.getSharedPreferences("growing3_sender", Context.MODE_PRIVATE);
+        processLock = new ProcessLock(context, EventSenderProvider.class.getName());
+        this.context = context;
     }
 
     public void flush(){
-        mSendHandler.flush();
+        sendHandler.flush();
     }
 
+    @Override
     public void shutdown() {
-        mProcessLock.release();
-        mSendHandler.removeCallbacksAndMessages(null);
+        processLock.release();
+        sendHandler.removeCallbacksAndMessages(null);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            mSendHandler.getLooper().quitSafely();
+            sendHandler.getLooper().quitSafely();
         } else {
-            mSendHandler.getLooper().quit();
+            sendHandler.getLooper().quit();
         }
     }
 
     private ModelLoader<EventDatabase, EventDbResult> getDatabaseModelLoader() {
-        return mRegistry.getModelLoader(EventDatabase.class, EventDbResult.class);
+        return this.context.getRegistry().getModelLoader(EventDatabase.class, EventDbResult.class);
     }
 
     private EventDbResult databaseOperation(EventDatabase eventDatabase) {
@@ -102,8 +100,9 @@ public class EventSender {
         return loadData.fetcher.executeData();
     }
 
-    void setEventNetSender(IEventNetSender mEventNetSender) {
-        this.mEventNetSender = mEventNetSender;
+    // for test
+    void setEventNetSender(IEventNetSender eventNetSender) {
+        this.eventNetSender = eventNetSender;
     }
 
     public void cacheEvent(GEvent event) {
@@ -114,9 +113,9 @@ public class EventSender {
     public void sendEvent(GEvent event) {
         databaseOperation(EventDatabase.insert(event));
         if (event.getSendPolicy() == SEND_POLICY_INSTANT) {
-            mSendHandler.uploadInstantEvent();
+            sendHandler.uploadInstantEvent();
         } else {
-            mSendHandler.uploadUninstantEvent();
+            sendHandler.uploadUninstantEvent();
         }
     }
 
@@ -132,7 +131,7 @@ public class EventSender {
     private long todayBytes(long delta) {
         String dateKey = "today";
         String usedBytesKey = "today_bytes";
-        String todayStr = mSharedPreferences.getString(dateKey, "");
+        String todayStr = sharedPreferences.getString(dateKey, "");
 
         @SuppressLint("SimpleDateFormat")
         SimpleDateFormat dayFormat = new SimpleDateFormat("yyyyMMdd");
@@ -141,18 +140,18 @@ public class EventSender {
         long usedBytes;
         if (!realDayTime.equals(todayStr)) {
             // 新的一天， 重新计算
-            SharedPreferences.Editor editor = mSharedPreferences.edit();
+            SharedPreferences.Editor editor = sharedPreferences.edit();
             editor.putString(dateKey, realDayTime);
             editor.putLong(usedBytesKey, 0);
             editor.apply();
             usedBytes = 0;
         } else {
             // 与记录数据是同一天
-            usedBytes = mSharedPreferences.getLong(usedBytesKey, 0);
+            usedBytes = sharedPreferences.getLong(usedBytesKey, 0);
         }
         if (delta > 0) {
             usedBytes = usedBytes + delta;
-            mSharedPreferences.edit().putLong(usedBytesKey, usedBytes).apply();
+            sharedPreferences.edit().putLong(usedBytesKey, usedBytes).apply();
         }
         return usedBytes;
     }
@@ -167,7 +166,7 @@ public class EventSender {
 
     @SuppressLint("WrongConstant")
     private ActivityManager.MemoryInfo getMemoryInfo() {
-        ActivityManager activityManager = (ActivityManager) mContext.getSystemService(Context.ACTIVITY_SERVICE);
+        ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
         ActivityManager.MemoryInfo memoryInfo = new ActivityManager.MemoryInfo();
         activityManager.getMemoryInfo(memoryInfo);
         return memoryInfo;
@@ -187,12 +186,12 @@ public class EventSender {
      * @param onlyInstant true -- 仅发送实时消息
      */
     void sendEvents(boolean onlyInstant) {
-        if (!mProcessLock.isAcquired()) {
+        if (!processLock.isAcquired()) {
             Logger.w(TAG, "sdk sendEvents will in main process,not in sub process.");
             return;
         }
 
-        NetworkUtil.NetworkState networkState = NetworkUtil.getActiveNetworkState(mContext);
+        NetworkUtil.NetworkState networkState = NetworkUtil.getActiveNetworkState(context);
         if (!networkState.isConnected()) {
             return;
         }
@@ -207,6 +206,8 @@ public class EventSender {
         }
 
         boolean succeeded = true;
+        long cellularDataLimit = configurationProvider.core().getCellularDataLimit();
+        long cellularDataLimitTotal = cellularDataLimit* 1024L * 1024L;
         for (int policy : uploadEvents) {
             if (!succeeded) {
                 Logger.e(TAG, "upload events break with http failed.");
@@ -215,16 +216,16 @@ public class EventSender {
             do {
                 if (policy != SEND_POLICY_INSTANT
                         && networkState.isMobileData()
-                        && mCellularDataLimit < todayBytes(0)) {
+                        && cellularDataLimitTotal < todayBytes(0)) {
                     Logger.w(TAG, "Today's mobile data is exhausted");
                     break;
                 }
                 EventDbResult dbResult = databaseOperation(EventDatabase.query(policy, numOfMaxEventsPerRequest()));
                 if (dbResult.isSuccess() && dbResult.getSum() > 0) {
-                    if (mEventNetSender == null) {
+                    if (eventNetSender == null) {
                         succeeded = false;
                     } else {
-                        SendResponse sendResponse = mEventNetSender.send(dbResult.getData(), dbResult.getMediaType());
+                        SendResponse sendResponse = eventNetSender.send(dbResult.getData(), dbResult.getMediaType());
                         succeeded = sendResponse.isSucceeded();
                         int responseCode = sendResponse.getResponseCode();
                         if (succeeded) {
@@ -233,7 +234,7 @@ public class EventSender {
                             if (networkState.isMobileData()) {
                                 todayBytes(sendResponse.getUsedBytes());
                             }
-                            mSendHandler.resetBackoff();
+                            sendHandler.resetBackoff();
                         } else if (responseCode == 413) {
                             String eventType = dbResult.getEventType();
                             databaseOperation(EventDatabase.delete(dbResult.getLastId(), policy, eventType));
@@ -247,7 +248,7 @@ public class EventSender {
                             databaseOperation(EventDatabase.update(dbResult.getLastId(), dbResult.getEventType()));
                             // Logger.e(TAG, "action: sendEvents, backoff with some reasons,eg: Unavailable For Legal Reasons");
                             // 5xx Service Unavailable
-                            mSendHandler.backoff();
+                            sendHandler.backoff();
                             Logger.e(TAG, "action: sendEvents, service unavailable with responseCode: " + responseCode);
                             break;
                         }
@@ -260,12 +261,11 @@ public class EventSender {
         }
     }
 
-
     EventDbResult getGEventsFromPolicy(int policy) {
         return databaseOperation(EventDatabase.queryAndDelete(policy, numOfMaxEventsPerRequest()));
     }
 
-    // 由于数据发送是耗时操作，网络端更有可能被block，所以这里另起一个线程处理
+
     private final class SendHandler extends Handler {
         private static final int MSG_SEND_INSTANT_EVENTS = 1;
         private static final int MSG_SEND_UNINSTANT_EVENTS = 2;

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventSenderProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventSenderProvider.java
@@ -62,12 +62,14 @@ public class EventSenderProvider implements TrackerLifecycleProvider {
         configurationProvider = context.getConfigurationProvider();
         long dataUploadInterval = configurationProvider.core().getDataUploadInterval();
 
+        sharedPreferences = context.getSharedPreferences("growing3_sender", Context.MODE_PRIVATE);
+        processLock = new ProcessLock(context, EventSenderProvider.class.getName());
+
+        eventNetSender = new EventHttpSender(context);
+
         HandlerThread thread = new HandlerThread(EventSenderProvider.class.getName());
         thread.start();
         sendHandler = new EventSenderProvider.SendHandler(thread.getLooper(), dataUploadInterval * 1000L);
-        eventNetSender = new EventHttpSender(context);
-        sharedPreferences = context.getSharedPreferences("growing3_sender", Context.MODE_PRIVATE);
-        processLock = new ProcessLock(context, EventSenderProvider.class.getName());
         this.context = context;
     }
 

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventSenderProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventSenderProvider.java
@@ -54,7 +54,7 @@ public class EventSenderProvider implements TrackerLifecycleProvider {
     private EventSenderProvider.SendHandler sendHandler;
     private IEventNetSender eventNetSender;
     private ProcessLock processLock;
-    private  SharedPreferences sharedPreferences;
+    private SharedPreferences sharedPreferences;
 
     @Override
     @SuppressWarnings("WrongConstant")

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventSenderProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventSenderProvider.java
@@ -74,7 +74,9 @@ public class EventSenderProvider implements TrackerLifecycleProvider {
     }
 
     public void flush() {
-        if (sendHandler != null) sendHandler.flush();
+        if (sendHandler != null && configurationProvider.core().isDataCollectionEnabled()) {
+            sendHandler.flush();
+        }
     }
 
     @Override

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventSenderProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventSenderProvider.java
@@ -54,7 +54,7 @@ public class EventSenderProvider implements TrackerLifecycleProvider {
     private EventSenderProvider.SendHandler sendHandler;
     private IEventNetSender eventNetSender;
     private ProcessLock processLock;
-    private SharedPreferences sharedPreferences;
+    private  SharedPreferences sharedPreferences;
 
     @Override
     @SuppressWarnings("WrongConstant")
@@ -64,17 +64,17 @@ public class EventSenderProvider implements TrackerLifecycleProvider {
 
         sharedPreferences = context.getSharedPreferences("growing3_sender", Context.MODE_PRIVATE);
         processLock = new ProcessLock(context, EventSenderProvider.class.getName());
-
         eventNetSender = new EventHttpSender(context);
 
         HandlerThread thread = new HandlerThread(EventSenderProvider.class.getName());
         thread.start();
         sendHandler = new EventSenderProvider.SendHandler(thread.getLooper(), dataUploadInterval * 1000L);
+
         this.context = context;
     }
 
-    public void flush(){
-        sendHandler.flush();
+    public void flush() {
+        if (sendHandler != null) sendHandler.flush();
     }
 
     @Override
@@ -188,7 +188,7 @@ public class EventSenderProvider implements TrackerLifecycleProvider {
      * @param onlyInstant true -- 仅发送实时消息
      */
     void sendEvents(boolean onlyInstant) {
-        if (!processLock.isAcquired()) {
+        if (processLock == null || !processLock.isAcquired()) {
             Logger.w(TAG, "sdk sendEvents will in main process,not in sub process.");
             return;
         }
@@ -209,7 +209,7 @@ public class EventSenderProvider implements TrackerLifecycleProvider {
 
         boolean succeeded = true;
         long cellularDataLimit = configurationProvider.core().getCellularDataLimit();
-        long cellularDataLimitTotal = cellularDataLimit* 1024L * 1024L;
+        long cellularDataLimitTotal = cellularDataLimit * 1024L * 1024L;
         for (int policy : uploadEvents) {
             if (!succeeded) {
                 Logger.e(TAG, "upload events break with http failed.");
@@ -334,7 +334,7 @@ public class EventSenderProvider implements TrackerLifecycleProvider {
             }
         }
 
-        private void flush(){
+        private void flush() {
             removeMessages(MSG_SEND_UNINSTANT_EVENTS);
             sendEmptyMessage(MSG_SEND_UNINSTANT_EVENTS);
         }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventSenderProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventSenderProvider.java
@@ -60,7 +60,7 @@ public class EventSenderProvider implements TrackerLifecycleProvider {
     @SuppressWarnings("WrongConstant")
     public void setup(TrackerContext context) {
         configurationProvider = context.getConfigurationProvider();
-        long dataUploadInterval = configurationProvider.core().getDataUploadInterval();
+        long dataUploadInterval = configurationProvider.core().isDebugEnabled() ? 0L : configurationProvider.core().getDataUploadInterval();
 
         sharedPreferences = context.getSharedPreferences("growing3_sender", Context.MODE_PRIVATE);
         processLock = new ProcessLock(context, EventSenderProvider.class.getName());

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/SessionProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/SessionProvider.java
@@ -36,6 +36,7 @@ public class SessionProvider implements IActivityLifecycle, TrackerLifecycleProv
     private ConfigurationProvider configurationProvider;
     private PersistentDataProvider persistentDataProvider;
     private ActivityStateProvider activityStateProvider;
+    private EventSenderProvider eventSenderProvider;
 
     protected SessionProvider() {
     }
@@ -46,6 +47,7 @@ public class SessionProvider implements IActivityLifecycle, TrackerLifecycleProv
         configurationProvider = context.getConfigurationProvider();
         sessionInterval = configurationProvider.core().getSessionInterval() * 1000L;
         persistentDataProvider = context.getProvider(PersistentDataProvider.class);
+        eventSenderProvider = context.getProvider(EventSenderProvider.class);
         activityList.clear();
         activityStateProvider = context.getActivityStateProvider();
         activityStateProvider.registerActivityLifecycleListener(this);
@@ -117,6 +119,7 @@ public class SessionProvider implements IActivityLifecycle, TrackerLifecycleProv
                         @Override
                         public void run() {
                             TrackEventGenerator.generateAppClosedEvent();
+                            eventSenderProvider.flush();
                         }
                     });
                 }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/TrackerLifecycleProviderFactory.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/TrackerLifecycleProviderFactory.java
@@ -56,6 +56,7 @@ public class TrackerLifecycleProviderFactory {
         providerStore.put(EventBuilderProvider.class, new EventBuilderProvider());
         providerStore.put(TimingEventProvider.class, new TimingEventProvider());
         providerStore.put(UserInfoProvider.class, new UserInfoProvider());
+        providerStore.put(EventSenderProvider.class, new EventSenderProvider());
 
         return providerStore;
     }

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/TrackerTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/TrackerTest.java
@@ -80,6 +80,8 @@ public class TrackerTest {
         testLibraryGioModule.registerComponents(tracker.getContext());
 
         tracker.registerComponent(testLibraryGioModule);
+
+        tracker.flushEvents();
     }
 
     @Test

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/providers/EventSenderProviderTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/providers/EventSenderProviderTest.java
@@ -1,19 +1,19 @@
 /*
- * Copyright (C) 2023 Beijing Yishu Technology Co., Ltd.
+ *  Copyright (C) 2026 Beijing Yishu Technology Co., Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
-package com.growingio.android.sdk.track.middleware;
+package com.growingio.android.sdk.track.providers;
 
 import android.app.Application;
 import android.content.pm.ProviderInfo;
@@ -28,6 +28,9 @@ import com.growingio.android.sdk.Tracker;
 import com.growingio.android.sdk.TrackerContext;
 import com.growingio.android.sdk.track.events.CustomEvent;
 import com.growingio.android.sdk.track.events.TrackEventType;
+import com.growingio.android.sdk.track.middleware.EventDatabase;
+import com.growingio.android.sdk.track.middleware.EventDbResult;
+import com.growingio.android.sdk.track.middleware.SendResponse;
 import com.growingio.android.sdk.track.middleware.format.EventByteArray;
 import com.growingio.android.sdk.track.middleware.format.EventFormatData;
 import com.growingio.android.database.DatabaseDataLoader;
@@ -50,28 +53,28 @@ import java.util.concurrent.TimeUnit;
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
-public class EventSenderTest {
+public class EventSenderProviderTest {
 
     private final ContentProviderController<EventDataContentProvider> controller =
             Robolectric.buildContentProvider(EventDataContentProvider.class);
     private final Application application = ApplicationProvider.getApplicationContext();
-    private EventSender eventSender;
 
     private TrackerContext context;
+    private EventSenderProvider eventSenderProvider;
 
     @Before
     public void setup() {
         context = new Tracker(application).getContext();
         ProviderInfo providerInfo = new ProviderInfo();
         providerInfo.authority = application.getPackageName() + "." + EventDataContentProvider.class.getSimpleName();
-
-        eventSender = new EventSender(application, context.getRegistry(), null, 0, 10);
         controller.create(providerInfo).get();
+
+        this.eventSenderProvider = context.getProvider(EventSenderProvider.class);
     }
 
     @Test
     public void eventSendTest() {
-        eventSender.setEventNetSender((events, mediaType) -> {
+        eventSenderProvider.setEventNetSender((events, mediaType) -> {
             try {
                 EventV3Protocol.EventV3List list = EventV3Protocol.EventV3List.parseFrom(events);
                 Truth.assertThat(list.getSerializedSize()).isEqualTo(1);
@@ -81,7 +84,7 @@ public class EventSenderTest {
             }
             return new SendResponse(204, 1000L);
         });
-        eventSender.sendEvent(new CustomEvent.Builder()
+        eventSenderProvider.sendEvent(new CustomEvent.Builder()
                 .setEventName("cpacm")
                 .build());
         Robolectric.flushForegroundThreadScheduler();
@@ -93,17 +96,17 @@ public class EventSenderTest {
     public void eventCacheTestPb() throws InvalidProtocolBufferException {
         context.getRegistry().register(EventDatabase.class, EventDbResult.class, new DatabaseDataLoader.Factory(context));
         context.getRegistry().register(EventFormatData.class, EventByteArray.class, new ProtobufDataLoader.Factory());
-        eventSender.removeAllEvents();
+        eventSenderProvider.removeAllEvents();
         CustomEvent ce = new CustomEvent.Builder()
                 .setEventName("cpacm").build();
-        eventSender.cacheEvent(ce);
-        eventSender.cacheEvent(ce);
-        eventSender.cacheEvent(ce);
-        EventDbResult dbResult = eventSender.getGEventsFromPolicy(ce.getSendPolicy());
+        eventSenderProvider.cacheEvent(ce);
+        eventSenderProvider.cacheEvent(ce);
+        eventSenderProvider.cacheEvent(ce);
+        EventDbResult dbResult = eventSenderProvider.getGEventsFromPolicy(ce.getSendPolicy());
         EventV3Protocol.EventV3List list = EventV3Protocol.EventV3List.parseFrom(dbResult.getData());
         Truth.assertThat(list.getValuesCount()).isEqualTo(3);
 
-        eventSender.setEventNetSender((events, mediaType) -> {
+        eventSenderProvider.setEventNetSender((events, mediaType) -> {
             try {
                 EventV3Protocol.EventV3List list1 = EventV3Protocol.EventV3List.parseFrom(events);
                 for (EventV3Protocol.EventV3Dto dto : list1.getValuesList()) {
@@ -116,9 +119,9 @@ public class EventSenderTest {
             }
             return new SendResponse(204, 1000L);
         });
-        eventSender.cacheEvent(ce);
-        eventSender.cacheEvent(ce);
-        eventSender.sendEvents(false);
+        eventSenderProvider.cacheEvent(ce);
+        eventSenderProvider.cacheEvent(ce);
+        eventSenderProvider.sendEvents(false);
         Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
     }
 
@@ -129,15 +132,15 @@ public class EventSenderTest {
 
         CustomEvent ce = new CustomEvent.Builder()
                 .setEventName("cpacm").build();
-        eventSender.cacheEvent(ce);
-        eventSender.cacheEvent(ce);
-        eventSender.cacheEvent(ce);
-        EventDbResult dbResult = eventSender.getGEventsFromPolicy(ce.getSendPolicy());
+        eventSenderProvider.cacheEvent(ce);
+        eventSenderProvider.cacheEvent(ce);
+        eventSenderProvider.cacheEvent(ce);
+        EventDbResult dbResult = eventSenderProvider.getGEventsFromPolicy(ce.getSendPolicy());
         String result = new String(dbResult.getData());
         JSONArray jsonArray = new JSONArray(result);
         Truth.assertThat(jsonArray.length()).isEqualTo(3);
 
-        eventSender.setEventNetSender((events, mediaType) -> {
+        eventSenderProvider.setEventNetSender((events, mediaType) -> {
             try {
                 JSONArray array = new JSONArray(new String(events));
                 for (int i = 0; i < array.length(); i++) {
@@ -153,9 +156,9 @@ public class EventSenderTest {
 
             return new SendResponse(204, 1000L);
         });
-        eventSender.cacheEvent(ce);
-        eventSender.cacheEvent(ce);
-        eventSender.sendEvents(false);
+        eventSenderProvider.cacheEvent(ce);
+        eventSenderProvider.cacheEvent(ce);
+        eventSenderProvider.sendEvents(false);
         Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
         // Used for snapshots
-        maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
         maven { url "https://plugins.gradle.org/m2/" }
     }
 }
@@ -15,7 +15,7 @@ dependencyResolutionManagement {
         mavenCentral()
         mavenLocal()
         // Used for snapshots
-        maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
 
         flatDir {
             dirs 'thirdLibs'


### PR DESCRIPTION
## PR 内容

添加新接口：flushEvents()，用于强制将事件发送至服务端。

新增两个场景自动调用flush接口：
1. app进入后台；
2. app重新连接网络。

## 测试步骤

1. 设置debug为false;
3. 生成一定数量事件；
4. 调用 flushEvents 接口，观察是否上传事件。


## 影响范围

<!-- 请描述你的PR能造成的影响范围. -->


## 是否属于重要变动？

- [ ] 是
- [x] 否


## 其他信息


