### PR TITLE
fix: prevent crash when accessing resources of detached fragments

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ protobufPlugin = "0.9.5"
 protobuf = "4.31.1"
 
 # !!! SDK VERSION !!!
-growingio = "4.5.3"
+growingio = "4.5.4-SNAPSHOT"
 growingioCode = "40503"
 growingioPlugin = "4.5.2"
 junit = "1.1.5"

--- a/gradle/publishAllToMavenLocal.sh
+++ b/gradle/publishAllToMavenLocal.sh
@@ -21,6 +21,7 @@
 && ./gradlew :growingio-compose:publishMavenPublicationToMavenLocal \
 && ./gradlew :growingio-tools:platform:publishMavenPublicationToMavenLocal \
 && ./gradlew :growingio-tools:oaid:publishMavenPublicationToMavenLocal \
+&& ./gradlew :growingio-compose:publishMavenPublicationToMavenLocal \
 && ./gradlew :gio-sdk:tracker:publishMavenPublicationToMavenLocal \
 && ./gradlew :gio-sdk:tracker-cdp:publishMavenPublicationToMavenLocal \
 && ./gradlew :gio-sdk:autotracker:publishMavenPublicationToMavenLocal \

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/SuperFragment.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/SuperFragment.java
@@ -137,7 +137,7 @@ public abstract class SuperFragment<T> {
             if (getRealFragment() == null || id == View.NO_ID) return null;
             try {
                 return getRealFragment().getResources().getResourceEntryName(id);
-            } catch (Resources.NotFoundException ignored) {
+            } catch (Exception ignored) {
             }
             return null;
         }
@@ -208,7 +208,7 @@ public abstract class SuperFragment<T> {
             if (getRealFragment() == null || id == View.NO_ID) return null;
             try {
                 return getRealFragment().getResources().getResourceEntryName(id);
-            } catch (Resources.NotFoundException ignored) {
+            } catch (Exception ignored) {
             }
             return null;
         }
@@ -279,7 +279,7 @@ public abstract class SuperFragment<T> {
             if (getRealFragment() == null || id == View.NO_ID) return null;
             try {
                 return getRealFragment().getResources().getResourceEntryName(id);
-            } catch (Resources.NotFoundException ignored) {
+            } catch (Exception ignored) {
             }
             return null;
         }

--- a/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/SuperFragment.java
+++ b/growingio-autotracker-core/src/main/java/com/growingio/android/sdk/autotrack/page/SuperFragment.java
@@ -17,7 +17,6 @@ package com.growingio.android.sdk.autotrack.page;
 
 import android.app.Activity;
 import android.app.Fragment;
-import android.content.res.Resources;
 import android.view.View;
 
 import androidx.annotation.Nullable;

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/view/ScreenshotUtil.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/view/ScreenshotUtil.java
@@ -22,6 +22,8 @@ import android.graphics.Canvas;
 import android.graphics.Matrix;
 import android.graphics.Rect;
 import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Base64;
 import android.util.DisplayMetrics;
 import android.view.PixelCopy;
@@ -110,9 +112,9 @@ public class ScreenshotUtil {
                         bitmap, copyResult -> {
                             if (copyResult == PixelCopy.SUCCESS) {
                                 Bitmap screenshot = WindowHelper.get().tryRenderDialog(activity, bitmap);
-                                callback.onScreenshot(scaleBitmap(screenshot, scale));
+                                TrackMainThread.trackMain().postActionToTrackMain(() -> callback.onScreenshot(scaleBitmap(screenshot, scale)));
                             }
-                        }, TrackMainThread.trackMain().getMainHandler());
+                        }, new Handler(Looper.getMainLooper()));
             } catch (IllegalArgumentException e) {
                 getScreenShotBitmapDefault(scale, callback);
             }
@@ -123,8 +125,10 @@ public class ScreenshotUtil {
     }
 
     private static void getScreenShotBitmapDefault(float scale, ScreenshotCallback callback) {
-        Bitmap originBitmap = getScreenshotBitmap();
-        callback.onScreenshot(scaleBitmap(originBitmap, scale));
+        TrackMainThread.trackMain().runOnUiThread(() -> {
+            Bitmap originBitmap = getScreenshotBitmap();
+            TrackMainThread.trackMain().postActionToTrackMain(() -> callback.onScreenshot(scaleBitmap(originBitmap, scale)));
+        });
     }
 
     private static Bitmap scaleBitmap(Bitmap bitmap, float scale) {


### PR DESCRIPTION
## PR 内容
1. Replaced catch (Resources.NotFoundException ignored) with catch (Exception ignored) across all SuperFragment implementations (SystemFragment, V4Fragment, and AndroidXFragment). This ensures that if a fragment is detached or the resource is missing, it will safely return null instead of crashing.
2. Execute the draw method on the main thread during screenshot capture

## 测试步骤


## 影响范围
无


## 是否属于重要变动？

- [ ] 是
- [x] 否


## 其他信息


