### PR TITLE
fix: ANLSPI-33965 修复 system_server 死亡导致的 DeadSystemRuntimeException 崩溃

### DIFF
--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/ActivityStateProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/ActivityStateProvider.java
@@ -253,7 +253,6 @@ public class ActivityStateProvider extends ListenerContainer<IActivityLifecycle,
             @Override
             public void onReceive(Context context, Intent intent) {
                 if (ConnectivityManager.CONNECTIVITY_ACTION.equals(intent.getAction())) {
-                    // 复用 NetworkUtil，避免重复实现同一套 binder 调用（见 NetworkUtil#getActiveNetworkInfo 的兜底）
                     if (NetworkUtil.getActiveNetworkState(context).isConnected()) {
                         Logger.i(TAG, "Network is available, flush messages.");
                         if (eventSenderProvider != null) eventSenderProvider.flush();

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/ActivityStateProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/ActivityStateProvider.java
@@ -25,7 +25,6 @@ import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.Network;
 import android.net.NetworkCapabilities;
-import android.net.NetworkInfo;
 import android.net.NetworkRequest;
 import android.os.Build;
 import android.os.Bundle;
@@ -38,6 +37,7 @@ import com.growingio.android.sdk.track.listener.ListenerContainer;
 import com.growingio.android.sdk.track.listener.event.ActivityLifecycleEvent;
 import com.growingio.android.sdk.track.log.Logger;
 import com.growingio.android.sdk.track.utils.ActivityUtil;
+import com.growingio.android.sdk.track.utils.NetworkUtil;
 import com.growingio.android.sdk.track.utils.SysTrace;
 
 import java.lang.ref.WeakReference;
@@ -253,10 +253,8 @@ public class ActivityStateProvider extends ListenerContainer<IActivityLifecycle,
             @Override
             public void onReceive(Context context, Intent intent) {
                 if (ConnectivityManager.CONNECTIVITY_ACTION.equals(intent.getAction())) {
-                    ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-                    if (cm == null) return;
-                    NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
-                    if (activeNetwork != null && activeNetwork.isConnected()) {
+                    // 复用 NetworkUtil，避免重复实现同一套 binder 调用（见 NetworkUtil#getActiveNetworkInfo 的兜底）
+                    if (NetworkUtil.getActiveNetworkState(context).isConnected()) {
                         Logger.i(TAG, "Network is available, flush messages.");
                         if (eventSenderProvider != null) eventSenderProvider.flush();
                     }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventSenderProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventSenderProvider.java
@@ -178,7 +178,7 @@ public class EventSenderProvider implements TrackerLifecycleProvider {
             }
         } catch (Throwable e) {
             // binder call to system_server, see NetworkUtil#getActiveNetworkInfo
-            Logger.w(TAG, "getMemoryInfo failed: " + e.getMessage());
+            Logger.w(TAG, e, "getMemoryInfo failed");
         }
         return memoryInfo;
     }
@@ -357,7 +357,7 @@ public class EventSenderProvider implements TrackerLifecycleProvider {
             try {
                 sendEvents(onlyInstant);
             } catch (Throwable e) {
-                Logger.e(TAG, "action: sendEvents failed: " + e.getMessage());
+                Logger.e(TAG, e, "action: sendEvents failed");
             }
         }
 

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventSenderProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventSenderProvider.java
@@ -350,8 +350,8 @@ public class EventSenderProvider implements TrackerLifecycleProvider {
 
 
         /**
-         * 该方法运行在 SDK 自己的 HandlerThread 上，任何未捕获的异常都会导致宿主 App 进程崩溃。
-         * 这里兜底后循环仍能继续，等系统恢复后自动重新上报。
+         * 运行在 SDK 自己的 HandlerThread 上，未捕获的异常会直接杀掉宿主 App 进程，因此这里必须兜底。
+         * 注意重新调度的逻辑要留在 catch 之外，否则一次异常会让上报循环永久停摆。
          */
         private void safelySendEvents(boolean onlyInstant) {
             try {

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventSenderProvider.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/providers/EventSenderProvider.java
@@ -170,9 +170,16 @@ public class EventSenderProvider implements TrackerLifecycleProvider {
 
     @SuppressLint("WrongConstant")
     private ActivityManager.MemoryInfo getMemoryInfo() {
-        ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
         ActivityManager.MemoryInfo memoryInfo = new ActivityManager.MemoryInfo();
-        activityManager.getMemoryInfo(memoryInfo);
+        try {
+            ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+            if (activityManager != null) {
+                activityManager.getMemoryInfo(memoryInfo);
+            }
+        } catch (Throwable e) {
+            // binder call to system_server, see NetworkUtil#getActiveNetworkInfo
+            Logger.w(TAG, "getMemoryInfo failed: " + e.getMessage());
+        }
         return memoryInfo;
     }
 
@@ -342,15 +349,27 @@ public class EventSenderProvider implements TrackerLifecycleProvider {
         }
 
 
+        /**
+         * 该方法运行在 SDK 自己的 HandlerThread 上，任何未捕获的异常都会导致宿主 App 进程崩溃。
+         * 这里兜底后循环仍能继续，等系统恢复后自动重新上报。
+         */
+        private void safelySendEvents(boolean onlyInstant) {
+            try {
+                sendEvents(onlyInstant);
+            } catch (Throwable e) {
+                Logger.e(TAG, "action: sendEvents failed: " + e.getMessage());
+            }
+        }
+
         @Override
         public void handleMessage(@NonNull Message msg) {
             switch (msg.what) {
                 case MSG_SEND_INSTANT_EVENTS:
-                    sendEvents(true);
+                    safelySendEvents(true);
                     break;
                 case MSG_SEND_UNINSTANT_EVENTS:
                     removeMessages(MSG_SEND_UNINSTANT_EVENTS);
-                    sendEvents(false);
+                    safelySendEvents(false);
                     if (backoffUploadInterval > 0) {
                         sendEmptyMessageDelayed(MSG_SEND_UNINSTANT_EVENTS, backoffUploadInterval);
                     }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/NetworkUtil.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/NetworkUtil.java
@@ -23,7 +23,11 @@ import android.telephony.TelephonyManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.growingio.android.sdk.track.log.Logger;
+
 public class NetworkUtil {
+    private static final String TAG = "NetworkUtil";
+
     public static class NetworkState {
         private final boolean mIsConnected;
         private final boolean mIsMobileData;
@@ -59,9 +63,16 @@ public class NetworkUtil {
 
     @Nullable
     private static NetworkInfo getActiveNetworkInfo(Context context) {
-        ConnectivityManager manager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-        if (manager != null) {
-            return manager.getActiveNetworkInfo();
+        try {
+            ConnectivityManager manager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+            if (manager != null) {
+                return manager.getActiveNetworkInfo();
+            }
+        } catch (Throwable e) {
+            // getActiveNetworkInfo() is a binder call to system_server. Once system_server dies,
+            // it throws DeadSystemRuntimeException(API 35+) or RuntimeException(DeadSystemException).
+            // Some ROMs also throw SecurityException here. None of them should crash the host app.
+            Logger.w(TAG, "getActiveNetworkInfo failed: " + e.getMessage());
         }
         return null;
     }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/NetworkUtil.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/NetworkUtil.java
@@ -69,9 +69,9 @@ public class NetworkUtil {
                 return manager.getActiveNetworkInfo();
             }
         } catch (Throwable e) {
-            // getActiveNetworkInfo() is a binder call to system_server. Once system_server dies,
-            // it throws DeadSystemRuntimeException(API 35+) or RuntimeException(DeadSystemException).
-            // Some ROMs also throw SecurityException here. None of them should crash the host app.
+            // binder call to system_server: throws DeadSystemRuntimeException(API 35+) or
+            // RuntimeException(DeadSystemException) once system_server dies, SecurityException on some ROMs.
+            // 这类系统级失败不应该让宿主 App 崩溃，降级为「网络不可用」即可。
             Logger.w(TAG, e, "getActiveNetworkInfo failed");
         }
         return null;

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/NetworkUtil.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/utils/NetworkUtil.java
@@ -72,7 +72,7 @@ public class NetworkUtil {
             // getActiveNetworkInfo() is a binder call to system_server. Once system_server dies,
             // it throws DeadSystemRuntimeException(API 35+) or RuntimeException(DeadSystemException).
             // Some ROMs also throw SecurityException here. None of them should crash the host app.
-            Logger.w(TAG, "getActiveNetworkInfo failed: " + e.getMessage());
+            Logger.w(TAG, e, "getActiveNetworkInfo failed");
         }
         return null;
     }

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/utils/NetworkUtilTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/utils/NetworkUtilTest.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (C) 2026 Beijing Yishu Technology Co., Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.growingio.android.sdk.track.utils;
+
+import android.app.Application;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.os.DeadSystemException;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.google.common.truth.Truth;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+/**
+ * 验证 system_server 死亡时 SDK 不会把异常抛给宿主 App。
+ * 参考线上堆栈：ConnectivityManager.getActiveNetworkInfo -> DeadSystemRuntimeException。
+ */
+@RunWith(RobolectricTestRunner.class)
+public class NetworkUtilTest {
+
+    @Test
+    @Config(shadows = {DeadSystemConnectivityManager.class})
+    public void getActiveNetworkStateWhenSystemServerDead() {
+        Application application = ApplicationProvider.getApplicationContext();
+
+        NetworkUtil.NetworkState state = NetworkUtil.getActiveNetworkState(application);
+
+        Truth.assertThat(state.isConnected()).isFalse();
+        Truth.assertThat(state.isWifi()).isFalse();
+        Truth.assertThat(state.isMobileData()).isFalse();
+        Truth.assertThat(state.getNetworkName()).isEqualTo(ConstantPool.UNKNOWN);
+    }
+
+    @Test
+    @Config(shadows = {SecurityRestrictedConnectivityManager.class})
+    public void getActiveNetworkStateWhenRomRestricted() {
+        Application application = ApplicationProvider.getApplicationContext();
+
+        NetworkUtil.NetworkState state = NetworkUtil.getActiveNetworkState(application);
+
+        Truth.assertThat(state.isConnected()).isFalse();
+        Truth.assertThat(state.getNetworkName()).isEqualTo(ConstantPool.UNKNOWN);
+    }
+
+    /**
+     * system_server 死亡后 framework 的表现。API 35+ 抛 DeadSystemRuntimeException，
+     * 更低版本抛 RuntimeException(DeadSystemException)，这里用后者，因为前者在 compileSdk 34 上不存在。
+     */
+    @Implements(ConnectivityManager.class)
+    public static class DeadSystemConnectivityManager {
+        @Implementation
+        protected NetworkInfo getActiveNetworkInfo() {
+            throw new RuntimeException(new DeadSystemException());
+        }
+    }
+
+    /** 部分 ROM 上的权限收紧行为。 */
+    @Implements(ConnectivityManager.class)
+    public static class SecurityRestrictedConnectivityManager {
+        @Implementation
+        protected NetworkInfo getActiveNetworkInfo() {
+            throw new SecurityException("permission denied by rom");
+        }
+    }
+}


### PR DESCRIPTION
## 问题

线上（4.4.1 及以上，含最新的 4.5.3）出现 `android.os.DeadSystemRuntimeException` 崩溃，92% 集中在 Android 16。

```
android.net.ConnectivityManager.getActiveNetworkInfo
com.growingio.android.sdk.track.utils.NetworkUtil.getActiveNetworkInfo:64
com.growingio.android.sdk.track.utils.NetworkUtil.getActiveNetworkState:71
com.growingio.android.sdk.track.middleware.EventSender.sendEvents:191
com.growingio.android.sdk.track.middleware.EventSender$SendHandler.handleMessage:339
android.os.Handler.dispatchMessage / Looper.loop / HandlerThread.run
```

mechanism: `UncaughtExceptionHandler`,  handled: `false`

## 原因

`ConnectivityManager.getActiveNetworkInfo()` 是到 `system_server` 的同步 binder 调用。`system_server` 死亡（系统软重启、OTA、厂商 ROM 系统进程崩溃）后，framework 的所有跨进程调用都会抛出 `DeadObjectException`，经 `RemoteException.rethrowFromSystemServer()` 转成 unchecked 异常抛给调用方。

`getActiveNetworkState()` → `sendEvents()` → `handleMessage()` 这一路没有任何 try/catch，异常直接冒泡到 `UncaughtExceptionHandler`，被记成 SDK 崩溃。

之所以偏偏是 SDK 报出来：`SendHandler` 是定时轮询的，不依赖用户操作，`sendEvents()` 第一件事就是取网络状态，所以进程内最先撞上死 binder 的大概率就是这个循环。

**关于 92% 集中在 Android 16**：`android.os.DeadSystemRuntimeException` 是 API 35 才新增的类型。在此之前 `rethrowFromSystemServer()` 抛的是 `RuntimeException`，cause 才是 `DeadSystemException`——也就是说 Android 14 及以下的同一崩溃会被聚合到另一个 issue 里，不出现在这个看板上。所以版本分布主要是异常类型改名带来的统计假象，叠加新系统 `system_server` 本身更不稳定，不是 Android 16 的行为变更。

## 改动

- `NetworkUtil.getActiveNetworkInfo()`：捕获 `Throwable`，失败返回 `null`。上层 `getActiveNetworkState()` 已有 `null` 分支会退化为「未连接」，`sendEvents()` 直接 return，行为安全。捕获 `Throwable` 而非 `Exception`，以覆盖部分 ROM 上的其它异常类型。
- `EventSenderProvider.getMemoryInfo()`：同一个上报线程里的另一处裸 binder 调用，`activityManager` 此前也未判空，一并补上兜底。失败时沿用 `MemoryInfo` 默认值（`lowMemory=false`），与正常设备行为一致。
- `SendHandler.handleMessage()`：抽出 `safelySendEvents()` 做兜底，避免上报线程上任何未捕获异常直接杀掉宿主进程。**重新调度的 `sendEmptyMessageDelayed()` 保留在 try 之外**，保证异常后上报循环不会永久停摆，系统恢复后能自动继续。

## 验证

- `./gradlew :growingio-tracker-core:compileDebugJavaWithJavac` ✅
- `./gradlew :growingio-tracker-core:testDebugUnitTest` ✅
- `./gradlew :growingio-tracker-core:spotlessCheck` ✅

## 后续可选优化（本 PR 未包含）

`BaseEvent.java:371` 每构造一个事件就调一次 `getActiveNetworkState()`，即每个事件一次同步 binder。可以改用 `NetworkCallback` 缓存网络状态，既彻底消除这个崩溃面，也能去掉这笔开销；同时 `NetworkInfo` 自 API 29 起已废弃，可一并迁移到 `getActiveNetwork()` + `NetworkCapabilities`。涉及生命周期管理，建议单独 PR 评估。

🤖 Generated with [Claude Code](https://claude.com/claude-code)