### PR TITLE
fix: 修复非 UI Context 使用触发的 StrictMode IncorrectContextUseViolation

### DIFF
--- a/growingio-compose/src/main/kotlin/com/growingio/android/compose/ComposeAutotrackProvider.kt
+++ b/growingio-compose/src/main/kotlin/com/growingio/android/compose/ComposeAutotrackProvider.kt
@@ -82,9 +82,8 @@ class ComposeAutotrackProvider :
         }
         // now we find some compose views in a new window.
         val window = WindowHelper.get().pullWindow(view)
-        val context = view.context.applicationContext
         if (window != null) {
-            val composeWindowCallback = GrowingWindowCallback(context, window, registry)
+            val composeWindowCallback = GrowingWindowCallback(view.context, window, registry)
             this.composeMaps[view.hashCode()] = composeWindowCallback
         }
     }

--- a/growingio-compose/src/main/kotlin/com/growingio/android/compose/GrowingWindowCallback.kt
+++ b/growingio-compose/src/main/kotlin/com/growingio/android/compose/GrowingWindowCallback.kt
@@ -16,6 +16,7 @@
 package com.growingio.android.compose
 
 import android.content.Context
+import android.os.Build
 import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.View
@@ -23,12 +24,13 @@ import android.view.ViewGroup
 import android.view.Window
 import androidx.core.view.GestureDetectorCompat
 import androidx.core.view.children
+import com.growingio.android.sdk.track.log.Logger
 import com.growingio.android.sdk.track.middleware.webservice.Circler
 import com.growingio.android.sdk.track.middleware.webservice.Debugger
 import com.growingio.android.sdk.track.middleware.webservice.WebService
 import com.growingio.android.sdk.track.modelloader.TrackerRegistry
 
-internal class GrowingWindowCallback(val context: Context, private val window: Window, private val registry: TrackerRegistry?) : WindowCallbackDelegate(window.callback) {
+internal class GrowingWindowCallback(context: Context, private val window: Window, private val registry: TrackerRegistry?) : WindowCallbackDelegate(window.callback) {
 
     init {
         window.callback = this
@@ -60,8 +62,10 @@ internal class GrowingWindowCallback(val context: Context, private val window: W
         }
     }
 
-    private val gestureDetect: GestureDetectorCompat = GestureDetectorCompat(
-        context.applicationContext,
+    // ViewConfiguration.get() 在 Android 15+ 会对非 UI Context 触发 StrictMode 违规，
+    // 因此这里必须用 decorView / window 的 UI Context，而不是 applicationContext。
+    private val gestureDetect: GestureDetectorCompat? = createGestureDetector(
+        uiContextOf(context, window),
         object : GestureDetector.OnGestureListener {
 
             override fun onDown(e: MotionEvent): Boolean = false
@@ -91,11 +95,13 @@ internal class GrowingWindowCallback(val context: Context, private val window: W
 
     override fun dispatchTouchEvent(event: MotionEvent?): Boolean {
         if (event != null) {
-            val obtain = MotionEvent.obtain(event)
-            try {
-                gestureDetect.onTouchEvent(obtain)
-            } finally {
-                obtain.recycle()
+            gestureDetect?.let { detector ->
+                val obtain = MotionEvent.obtain(event)
+                try {
+                    detector.onTouchEvent(obtain)
+                } finally {
+                    obtain.recycle()
+                }
             }
 
             if (event.action == MotionEvent.ACTION_UP) {
@@ -104,5 +110,24 @@ internal class GrowingWindowCallback(val context: Context, private val window: W
             }
         }
         return super.dispatchTouchEvent(event)
+    }
+
+    private companion object {
+        const val TAG = "GrowingWindowCallback"
+
+        fun uiContextOf(context: Context, window: Window): Context {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return context
+            if (context.isUiContext) return context
+            val windowContext = window.context
+            return if (windowContext.isUiContext) windowContext else context
+        }
+
+        fun createGestureDetector(context: Context, listener: GestureDetector.OnGestureListener): GestureDetectorCompat? = try {
+            GestureDetectorCompat(context, listener)
+        } catch (e: Exception) {
+            // StrictMode 可能配置了 penaltyDeath，此时构造会抛异常，降级为不采集 compose 点击
+            Logger.e(TAG, "create gesture detector failed: ${e.message}")
+            null
+        }
     }
 }

--- a/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/view/TipView.java
+++ b/growingio-tracker-core/src/main/java/com/growingio/android/sdk/track/view/TipView.java
@@ -15,7 +15,6 @@
  */
 package com.growingio.android.sdk.track.view;
 
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.Color;
@@ -38,8 +37,10 @@ import com.growingio.android.sdk.track.log.Logger;
 import com.growingio.android.sdk.track.utils.DeviceUtil;
 
 public class TipView extends FrameLayout {
-    private final Context mContext;
-    private final WindowManager mWindowManager;
+    private static final String TAG = "TipView";
+
+    // 挂载时取自宿主 Activity，remove 后置空，避免跨 Activity 持有
+    private WindowManager mWindowManager;
 
     private TextView mContent;
     private TextView mDragTip;
@@ -51,14 +52,22 @@ public class TipView extends FrameLayout {
     private int mViewLastY;
     private float mTouchDownY;
 
-    @SuppressLint("WrongConstant")
     public TipView(Context context) {
-        super(context);
-        mContext = context;
-        mWindowManager = (WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE);
+        super(configurationContext(context));
         setId(R.id.growing_webservices_tip_view);
         createView();
         setKeepScreenOn(true);
+    }
+
+    /**
+     * Android 11+ 的 StrictMode 会拒绝从非 UI Context 访问 ViewConfiguration 等配置相关 API。
+     * TipView 跨 Activity 复用，不能持有 Activity；而它挂载用的 TYPE_APPLICATION_PANEL 属于
+     * sub-window，无法通过 createWindowContext 升级，因此退而用 configuration context ——
+     * StrictMode#assertConfigurationContext 同样认可它。
+     */
+    private static Context configurationContext(Context context) {
+        if (context instanceof Activity) return context;
+        return context.createConfigurationContext(context.getResources().getConfiguration());
     }
 
     private void createView() {
@@ -81,7 +90,7 @@ public class TipView extends FrameLayout {
                 ViewGroup.LayoutParams.MATCH_PARENT));
         setBackgroundResource(R.color.growing_tracker_blue);
         mViewLastY = getStatusBarHeight();
-        mMinMoveDistance = ViewConfiguration.get(mContext).getScaledTouchSlop();
+        mMinMoveDistance = ViewConfiguration.get(getContext()).getScaledTouchSlop();
     }
 
     public void setContent(@StringRes int resid) {
@@ -119,7 +128,9 @@ public class TipView extends FrameLayout {
                 WindowManager.LayoutParams layoutParams = (WindowManager.LayoutParams) getLayoutParams();
                 layoutParams.y += offsetY;
                 mViewLastY = layoutParams.y;
-                mWindowManager.updateViewLayout(this, layoutParams);
+                if (mWindowManager != null) {
+                    mWindowManager.updateViewLayout(this, layoutParams);
+                }
                 break;
             case MotionEvent.ACTION_UP:
             case MotionEvent.ACTION_CANCEL:
@@ -149,9 +160,10 @@ public class TipView extends FrameLayout {
         show(activity);
     }
 
-    private void addView(IBinder windowToken) {
+    private void addView(Activity activity, IBinder windowToken) {
         if (!mIsShowing) {
             mIsShowing = true;
+            mWindowManager = activity.getWindowManager();
             WindowManager.LayoutParams layoutParams = new WindowManager.LayoutParams();
             layoutParams.type = WindowManager.LayoutParams.TYPE_APPLICATION_PANEL;
             layoutParams.token = windowToken;
@@ -169,12 +181,14 @@ public class TipView extends FrameLayout {
     public void remove() {
         if (mIsShowing) {
             try {
-                WindowManager windowManager = (WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE);
-                windowManager.removeView(this);
+                if (mWindowManager != null) {
+                    mWindowManager.removeView(this);
+                }
             } catch (Exception e) {
-                Logger.e("TipView", e);
+                Logger.e(TAG, e);
             } finally {
                 mIsShowing = false;
+                mWindowManager = null;
             }
         }
     }
@@ -197,13 +211,13 @@ public class TipView extends FrameLayout {
                 public void onGlobalLayout() {
                     IBinder token = activity.getWindow().getDecorView().getWindowToken();
                     if (token != null) {
-                        addView(token);
+                        addView(activity, token);
                         decorView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
                     }
                 }
             });
         } else {
-            addView(windowToken);
+            addView(activity, windowToken);
         }
     }
 }

--- a/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/view/TipViewTest.java
+++ b/growingio-tracker-core/src/test/java/com/growingio/android/sdk/track/view/TipViewTest.java
@@ -16,9 +16,12 @@
 package com.growingio.android.sdk.track.view;
 
 import android.app.Activity;
+import android.content.Context;
 import android.net.Uri;
 import android.view.MotionEvent;
 import android.view.WindowManager;
+
+import androidx.test.core.app.ApplicationProvider;
 
 import com.growingio.android.sdk.track.providers.RobolectricActivity;
 import com.growingio.android.sdk.track.middleware.webservice.Circler;
@@ -62,6 +65,22 @@ public class TipViewTest {
 
         tipView.ready(activity);
         tipView.show(activity);
+        tipView.dismiss();
+    }
+
+    @Test
+    public void tipViewWithApplicationContextTest() {
+        Activity activity = Robolectric.buildActivity(RobolectricActivity.class).create().resume().get();
+        Context application = ApplicationProvider.getApplicationContext();
+
+        // circler/debugger 传入的是 application context，TipView 需要把它升级为 configuration context，
+        // 否则 Android 11+ 上 ViewConfiguration.get() 会触发 StrictMode 的 IncorrectContextUseViolation
+        TipView tipView = new TipView(application);
+        assertThat(tipView.getContext()).isNotSameInstanceAs(application);
+
+        tipView.setContent("this is test tip");
+        tipView.show(activity);
+        tipView.remove();
         tipView.dismiss();
     }
 

--- a/growingio-webservice/circler/src/main/java/com/growingio/android/circler/ThreadSafeTipView.java
+++ b/growingio-webservice/circler/src/main/java/com/growingio/android/circler/ThreadSafeTipView.java
@@ -87,7 +87,10 @@ public class ThreadSafeTipView {
 
     public void setErrorMessage(int resid) {
         runOnUiThread(() -> {
-            tipView.setErrorMessage(context.getResources().getText(resid));
+            // 连接失败可能晚于 dismiss 到达，此时提示条已销毁，不再重建
+            if (tipView != null) {
+                tipView.setErrorMessage(context.getResources().getText(resid));
+            }
         });
     }
 

--- a/growingio-webservice/circler/src/test/java/com/growingio/android/circler/ScreenShotTest.java
+++ b/growingio-webservice/circler/src/test/java/com/growingio/android/circler/ScreenShotTest.java
@@ -119,6 +119,18 @@ public class ScreenShotTest {
         screenshotProvider.unregisterScreenshotRefreshedListener();
     }
 
+    @Test
+    public void tipViewMessageAfterDismissTest() {
+        ScreenshotProvider screenshotProvider = context.getProvider(ScreenshotProvider.class);
+        Activity activity = Robolectric.buildActivity(RobolectricActivity.class).create().resume().get();
+        ShadowWH.activity = activity;
+
+        screenshotProvider.enableTipViewShow();
+        screenshotProvider.disableTipView();
+        // onFailed 可能晚于 cancel() 到达，此时提示条已销毁
+        screenshotProvider.setTipViewMessage(R.string.growing_circler_connected_to_web_failed);
+    }
+
     public List<DecorView> getAllWindowDecorViews() {
         Activity activity = Robolectric.buildActivity(RobolectricActivity.class).create().resume().get();
         View view = activity.getWindow().getDecorView();

--- a/growingio-webservice/debugger/src/main/java/com/growingio/android/debugger/ThreadSafeTipView.java
+++ b/growingio-webservice/debugger/src/main/java/com/growingio/android/debugger/ThreadSafeTipView.java
@@ -87,7 +87,10 @@ public class ThreadSafeTipView {
 
     public void setErrorMessage(int resid) {
         runOnUiThread(() -> {
-            tipView.setErrorMessage(context.getResources().getText(resid));
+            // 连接失败可能晚于 dismiss 到达，此时提示条已销毁，不再重建
+            if (tipView != null) {
+                tipView.setErrorMessage(context.getResources().getText(resid));
+            }
         });
     }
 

--- a/growingio-webservice/debugger/src/test/java/com/growingio/android/debugger/ScreenShotTest.java
+++ b/growingio-webservice/debugger/src/test/java/com/growingio/android/debugger/ScreenShotTest.java
@@ -91,4 +91,16 @@ public class ScreenShotTest {
         screenshotProvider.sendScreenshotRefreshed("this test base64", 100);
     }
 
+    @Test
+    public void tipViewMessageAfterDismissTest() {
+        ScreenshotProvider screenshotProvider = context.getProvider(ScreenshotProvider.class);
+        Activity activity = Robolectric.buildActivity(RobolectricActivity.class).create().resume().get();
+        ShadowWH.activity = activity;
+
+        screenshotProvider.enableTipViewShow();
+        screenshotProvider.disableTipView();
+        // onFailed 可能晚于 cancel() 到达，此时提示条已销毁
+        screenshotProvider.setTipViewMessage(R.string.growing_debugger_connected_to_web_failed);
+    }
+
 }


### PR DESCRIPTION
## 问题

开启 `StrictMode.detectIncorrectContextUse()` 后，Compose 采集在 Activity resume 时打出违规日志：

```
java.lang.IllegalAccessException: Tried to access the API:ViewConfiguration which needs to
have proper configuration from a non-UI Context:com.growingio.demo.DemoApplication@4fd26d1
    at android.os.StrictMode.assertConfigurationContext(StrictMode.java:2424)
    at android.view.ViewConfiguration.get(ViewConfiguration.java:604)
    at android.view.GestureDetector.init(GestureDetector.java:584)
    at androidx.core.view.GestureDetectorCompat.<init>(GestureDetectorCompat.java:79)
    at com.growingio.android.compose.GrowingWindowCallback.<init>(GrowingWindowCallback.kt:63)
    at com.growingio.android.compose.ComposeAutotrackProvider.onDecorViewAdded(ComposeAutotrackProvider.kt:87)
    at com.growingio.android.sdk.track.view.WindowHelper$ObserverArrayList.add(WindowHelper.java:88)
    at android.view.WindowManagerGlobal.addView(WindowManagerGlobal.java:598)
    at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:6395)
```

`ViewConfiguration.get()` 依赖屏幕尺寸/密度等配置信息，从 Android 12 起被 StrictMode 纳入检测，必须传 UI Context（Activity、`createWindowContext()` 或 `createConfigurationContext()` 的产物）。

## 改动

### 1. Compose 采集（主问题）

`ComposeAutotrackProvider` 拿到 decorView 后取了 `applicationContext` 再传给 `GrowingWindowCallback`。decorView 自身的 context 本就是合格的 UI Context，白白降级了。

- 改传 `view.context`
- `GrowingWindowCallback` 不再把 context 存为属性（`GestureDetector` 只读取 `ViewConfiguration`，不持有 Context；`window` 本就持有它，无新增泄漏）
- 加 UI Context 兜底：API 31+ 用 `isUiContext` 校验，不合格时回退 `window.context`
- `GestureDetectorCompat` 构造包 try/catch —— 宿主 App 若配了 `penaltyDeath`，不应在 `handleResumeActivity` 期间把 App 打挂，降级为不采集 Compose 点击

### 2. TipView（同类隐患）

圈选/调试悬浮条同样用 application context 构造，`View.<init>` 和 `ViewConfiguration.get()` 都会违规。

它跨 Activity 复用（RESUMED 时 show、PAUSED 时 removeOnly），不能持有 Activity；挂载用的 `TYPE_APPLICATION_PANEL` 属于 sub-window，也无法用 `createWindowContext` 升级。因此按 StrictMode 的两条不同检查拆开处理：

- **配置类 API** → `createConfigurationContext()` 派生的 context。`assertConfigurationContext` 检查 `isUiContext() || mIsConfigurationBasedContext`，能通过且不持有 Activity
- **visual service**（`getSystemService(WINDOW_SERVICE)`）→ `WindowManager` 改为挂载时取自宿主 Activity、`remove()` 时置空。`updateViewLayout`/`removeView` 底层走 `WindowManagerGlobal` 进程单例，换实例不影响行为

### 3. 顺带修复：提示条销毁后设置错误文案的 NPE

`ThreadSafeTipView.setErrorMessage()`（circler/debugger 各一份）未做 null 检查，而 `CirclerService.onFailed()` 可能晚于 `cancel()` 到达，此时 `tipView` 已被 dismiss 置空。

选 null 检查而非补 `initView()`：该方法语义是"把已显示的提示条改成错误态"，重建只会得到一个 `mIsNeedShow=false` 的隐形 View 挂着；且 `onFailed()` 后续的 `showQuitDialog()` 仍会告知用户。

## 影响范围

这是个"沉默的 bug"——客户 App 同样在跑这段代码，只是要同时满足「显式开启 `detectIncorrectContextUse()`」+「debug 构建」+「接入 growingio-compose 且页面含 ComposeView」+「Android 12 以上」才会显形。demo 的 `StrictModeUtil.kt` 正好全部命中。

即便不开检测，`getScaledTouchSlop()` 取的是 Application Configuration 的值，在分屏、折叠屏展开、外接显示器等场景下与实际窗口不一致，触摸判定阈值本身就会偏。

## 测试

新增 3 个用例：

- `TipViewTest.tipViewWithApplicationContextTest` —— 覆盖 application context 分支（原有用例传的是 Activity，走不到）
- circler / debugger 各一个 `ScreenShotTest.tipViewMessageAfterDismissTest` —— 已验证"还原修复即 NPE 失败"

| 模块 | 结果 |
| --- | --- |
| `tracker-core` TipViewTest | 3 tests, 0 failures |
| `circler` ScreenShotTest / CirclerTest | 3 + 2 tests, 0 failures |
| `debugger` ScreenShotTest / DebuggerTest | 3 + 4 tests, 0 failures |

`:growingio-compose:compileDebugKotlin` 与全仓 `spotlessCheck` 通过。

## 参考

同类问题在社区里有两类处理方式——能拿到 UI Context 的就换，拿不到的长期挂着不修：

- [square/leakcanary#2153](https://github.com/square/leakcanary/issues/2153) —— 作者确认"当初为避免泄漏才改用 application context，现在得改回来"，修复 commit [`02f977d`](https://github.com/square/leakcanary/commit/02f977dc01ef9832cb661406707bdb7a7219852c) 正是换回 UI Context
- [facebook/fresco#2611](https://github.com/facebook/fresco/issues/2611) —— 同样是 `GestureDetector` + `applicationContext`，注释写着"we should always use the application context to avoid memory leaks"，至今未修
- [googlemaps/android-maps-compose#612](https://github.com/googlemaps/android-maps-compose/issues/612) —— 报错文案逐字相同，官方以"问题在底层 MapView"关闭
- Sentry Android SDK 采用同样的 `Window.Callback` + `GestureDetector` 架构，`UserInteractionIntegration` 传入的是 **activity** 而非 applicationContext

🤖 Generated with [Claude Code](https://claude.com/claude-code)