### PR TITLE
chore: release 4.5.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,8 +31,8 @@ protobufPlugin = "0.9.5"
 protobuf = "4.31.1"
 
 # !!! SDK VERSION !!!
-growingio = "4.5.4-SNAPSHOT"
-growingioCode = "40503"
+growingio = "4.5.4"
+growingioCode = "40504"
 growingioPlugin = "4.5.2"
 junit = "1.1.5"
 


### PR DESCRIPTION
## PR 内容

将版本从 `4.5.4-SNAPSHOT` 定版为 `4.5.4`，为发布 Release-4.5.4 做准备。

```diff
-growingio = "4.5.4-SNAPSHOT"
-growingioCode = "40503"
+growingio = "4.5.4"
+growingioCode = "40504"
 growingioPlugin = "4.5.2"
```

顺带修掉一处不一致：`growingioCode` 在引入 `-SNAPSHOT` 时漏改，还停在 4.5.3 对应的 `40503`。

`growingioPlugin` 保持 `4.5.2` 不变 —— 插件是独立仓库、独立发版，Gradle Plugin Portal 上当前 `<release>` 即 4.5.2，无新版可升。（注意 Maven Central 的 `com.growingio.android:autotracker-gradle-plugin` 坐标只更新到 4.3.0，4.4.0 之后改发 Plugin Portal，查版本别看错地方。）

## 4.5.4 包含的内容

自 `v4.5.3` 以来合入 master 的三个修复：

- #241 修复 system_server 死亡导致的 DeadSystemRuntimeException 崩溃
- #242 修复非 UI Context 使用触发的 StrictMode IncorrectContextUseViolation
- #240 fix: prevent crash when accessing resources of detached fragments

全部是 bug fix，无 API 变更，patch 版本号合适。

## 测试步骤

版本号会经由 `growingio-tracker-core/build.gradle` 流入 `BuildConfig`，进而决定 `SDKConfig.SDK_VERSION`。已验证生成结果正确：

```java
public static final int VERSION_CODE = 40504;
public static final String VERSION_NAME = "4.5.4";
```

并已确认仓库内无其他硬编码的版本号引用（`demo/` 由 `gradle/preRelease.sh` 在 CI 中自动同步，无需手改）。

本地验证：`spotlessCheck`、`:growingio-tracker-core:testDebugUnitTest`、`:growingio-compose:compileDebugKotlin` 均通过。

## 影响范围

仅版本号。合入后即可创建 Release-4.5.4（tag `v4.5.4`，target `master`），由 `publish.yml` 自动发布至 Maven Central。

## 是否属于重要变动？

- [ ] 是
- [x] 否

🤖 Generated with [Claude Code](https://claude.com/claude-code)